### PR TITLE
Fixes #17: Newick: no property printed in internal branches

### DIFF
--- a/src/Bpp/Phyl/Io/Newick.cpp
+++ b/src/Bpp/Phyl/Io/Newick.cpp
@@ -543,8 +543,8 @@ string Newick::nodeToParenthesis(const PhyloTree& tree, const std::shared_ptr<Ph
     {
       if (it!=vSons.begin())
         s << ",";
-      
-      s << nodeToParenthesis(tree, *it);
+
+      s << nodeToParenthesis(tree, *it, bootstrap, propertyName);
     }
 
     s << ")";


### PR DESCRIPTION
The wrong function was called in the recursion.