### PR TITLE
Missing include <numeric>

### DIFF
--- a/src/Bpp/Phyl/NewLikelihood/NonHomogeneousSubstitutionProcess.h
+++ b/src/Bpp/Phyl/NewLikelihood/NonHomogeneousSubstitutionProcess.h
@@ -53,6 +53,7 @@
 #include <map>
 //#include <algorithm>
 #include <memory>
+#include <numeric>
 
 namespace bpp
 {


### PR DESCRIPTION
Failed compilation with clang (std::iota undefined)