### PR TITLE
Substitution model set edit

### DIFF
--- a/src/Bpp/Phyl/Likelihood/JointLikelihoodFunction.cpp
+++ b/src/Bpp/Phyl/Likelihood/JointLikelihoodFunction.cpp
@@ -1,0 +1,362 @@
+#include "JointLikelihoodFunction.h"
+
+// for bpp-core
+#include <Bpp/Numeric/Function/Functions.h>
+#include <Bpp/App/BppApplication.h>
+#include <Bpp/Numeric/AbstractParametrizable.h>
+#include <Bpp/App/BppApplication.h>
+#include <Bpp/App/ApplicationTools.h>
+#include <Bpp/Numeric/Prob/ConstantDistribution.h>
+#include <Bpp/Text/TextTools.h>
+#include <Bpp/Numeric/Function/BrentOneDimension.h>
+
+// From bpp-phyl:
+#include <Bpp/Phyl/Tree.h>
+#include <Bpp/Phyl/Node.h>
+#include <Bpp/Phyl/Likelihood/RASTools.h>
+#include <Bpp/Phyl/Likelihood/RHomogeneousTreeLikelihood.h>
+#include <Bpp/Phyl/Likelihood/RNonHomogeneousMixedTreeLikelihood.h>
+#include <Bpp/Phyl/App/PhylogeneticsApplicationTools.h>
+#include <Bpp/Phyl/OptimizationTools.h>
+#include <Bpp/Phyl/Model/SubstitutionModelSetTools.h>
+#include <Bpp/Phyl/Model/MixedSubstitutionModel.h>
+#include <Bpp/Phyl/Model/TwoParameterBinarySubstitutionModel.h>
+#include <Bpp/Phyl/Model/RateDistribution/ConstantRateDistribution.h>
+#include <Bpp/Phyl/Io/Newick.h>
+#include <Bpp/Phyl/Mapping/StochasticMapping.h>
+
+// From bpp-seq:
+#include <Bpp/Seq/Container/SiteContainer.h>
+#include <Bpp/Seq/Container/VectorSiteContainer.h>
+
+// From the STL:
+#include <iostream>
+#include <iomanip>
+#include <limits>
+#include <map>
+#include <vector>
+#include <math.h>       /* pow */
+#include <string>
+
+using namespace bpp;
+using namespace std;
+
+/******************************************************************************/
+
+JointLikelihoodFunction::JointLikelihoodFunction(BppApplication* bppml, const Tree* tree, const VectorSiteContainer* characterData, TransitionModel* characterModel, const VectorSiteContainer* sequenceData, MixedSubstitutionModelSet* sequenceModel, DiscreteDistribution* rDist):
+AbstractParametrizable(""), 
+hypothesis_(null),
+bppml_(bppml),
+characterTreeLikelihood_(),
+sequenceTreeLikelihood_(),
+stocMapping_(),
+optimizationScope_(none),
+logl_(0)
+{
+    // create the character likelihood function as data member based on the character model, character data and tree
+    RHomogeneousTreeLikelihood* characterTreeLikelihood = new RHomogeneousTreeLikelihood(*tree, *characterData, characterModel, rDist, false);
+    characterTreeLikelihood->initialize();
+    characterTreeLikelihood_ = characterTreeLikelihood;
+
+    // create the sequence tree likelihood of the null model as initial data memeber based on the sequence model, sequence data and tree
+    RNonHomogeneousMixedTreeLikelihood* sequenceTreeLikelihood = new RNonHomogeneousMixedTreeLikelihood(*tree, *sequenceData, sequenceModel, rDist, true, true);
+    sequenceTreeLikelihood->initialize();
+    sequenceTreeLikelihood_ = sequenceTreeLikelihood;
+
+    // create the stochadtic mapping data member based on the character likelihood function data member
+    size_t numOfMappings = static_cast<size_t>(ApplicationTools::getIntParameter("character.num_of_mappings", bppml_->getParams(), 100));
+    stocMapping_ = new StochasticMapping(dynamic_cast<TreeLikelihood*>(characterTreeLikelihood_), numOfMappings);
+
+    // set the parameters of the joint likelihood function instance as clones of the character model and sequence model parameters
+    ParameterList characterParameters = characterModel->getParameters();
+    for (size_t i=0; i<characterParameters.size(); ++i)
+    {
+        addParameter_(characterParameters[i].clone());
+    }
+    ParameterList sequenceParameters = sequenceModel->getParameters();
+    for (size_t j=0; j<sequenceParameters.size(); ++j)
+    {
+        addParameter_(sequenceParameters[j].clone());
+    }
+    ParameterList paramsToUpdate = getParameters();
+    fireParameterChanged(paramsToUpdate);
+}
+
+/******************************************************************************/
+
+JointLikelihoodFunction::~JointLikelihoodFunction()
+{
+    // delete the stochastic mapping
+    if (stocMapping_) delete stocMapping_;
+
+    // delete the likelihood function
+    if (characterTreeLikelihood_) delete characterTreeLikelihood_;
+
+    // delete the sequence likelihood function
+    if (sequenceTreeLikelihood_) delete sequenceTreeLikelihood_;
+
+    // deletion of the parameters created via the constrcutor us done by the the deletion of the inheriting class AbstractParametrizable
+}
+
+/******************************************************************************/
+
+void JointLikelihoodFunction::fireParameterChanged(const ParameterList& pl) 
+{
+    // update the values of the character model and sequence model, if required, before calling the function that computes the joint likelihood
+    for (size_t i=0; i<pl.size(); ++i)
+    {
+        if (hasParameter((pl[i]).getName()))
+        {
+            if ((pl[i]).getName().compare("Binary.rate") == 0) // enters here all the time
+            {
+                characterTreeLikelihood_->setParameterValue(pl[i].getName(),(pl[i]).getValue());
+            }
+            else if ((pl[i]).getName().compare("Binary.kappa") == 0)
+            {
+                characterTreeLikelihood_->setParameterValue(pl[i].getName(),(pl[i]).getValue());
+            } else { // the parameter belongs to the seuqence model
+                // if the parameter name ends with _1 (i.e, belongs to model1), or it is the selection intensity parameter, set is value (all other parameters are aliased and thus their value needen't be set)
+                string paramName = pl[i].getName();
+                if (paramName.substr(paramName.length()-2, 2).compare("_1") == 0 || paramName.substr(0,8).compare("RELAX.k_") == 0)
+                {
+                    sequenceTreeLikelihood_->setParameterValue(pl[i].getName(),(pl[i]).getValue());
+                }
+            }
+        }
+    }
+    
+    /* if a character parameter was changed -> call computeAlternativeJointLikelihood without sequence model optimization
+        else, the changed paramet der must be the boolean distating that the sequence model should be optimized */
+    switch(hypothesis_)
+    {
+        case null: 
+            computeNullJointLikelihood(); 
+            break;
+        case alternative: 
+            computeAlternativeJointLikelihood(); 
+            break;
+        default: 
+            throw Exception("Error! illegal hypothesis setting");
+    }
+}
+
+/******************************************************************************/
+
+void JointLikelihoodFunction::setPartitionByHistory(const Tree* history)
+{
+    sequenceTreeLikelihood_->getSubstitutionModelSet()->resetModelToNodels();
+    vector<const Node*> nodes = (dynamic_cast<const TreeTemplate<Node>*>(history))->getNodes();
+    for (size_t i=0; i<nodes.size(); ++i)
+    {
+      int nodeId = nodes[i]->getId();
+      if (nodes[i]->hasFather())
+      {
+        int nodeState = stocMapping_->getNodeState(nodes[i]);
+        if (nodeState == 0)
+        {
+            sequenceTreeLikelihood_->getSubstitutionModelSet()->setNodeToModel(0,nodeId);
+        }    
+        else
+        {
+            sequenceTreeLikelihood_->getSubstitutionModelSet()->setNodeToModel(1,nodeId);
+        }
+      }
+    }
+}
+
+/******************************************************************************/
+
+void JointLikelihoodFunction::updatesequenceTreeLikelihood(const Tree* history)
+{
+    // extract the input for the next SequenceTreeLikelihood from the previouts one
+    const VectorSiteContainer* sequenceData = dynamic_cast<const VectorSiteContainer*>(sequenceTreeLikelihood_->getData()->clone());
+    MixedSubstitutionModelSet* sequenceModel = dynamic_cast<MixedSubstitutionModelSet*>(sequenceTreeLikelihood_->getSubstitutionModelSet());
+    DiscreteDistribution* rDist = RASTools::getPosteriorRateDistribution(*sequenceTreeLikelihood_);
+
+    // create the new sequenceTreeLikelihood
+    RNonHomogeneousMixedTreeLikelihood* sequenceTreeLikelihood = new RNonHomogeneousMixedTreeLikelihood(*history, *sequenceData, sequenceModel, rDist, true, true);
+    sequenceTreeLikelihood->initialize();
+
+    // delete the previous SequenceTreeLikelihood instance
+    if (sequenceTreeLikelihood_) delete sequenceTreeLikelihood_;
+
+    // assign a new sequenceTreeLikelihood instnace
+    sequenceTreeLikelihood_ = sequenceTreeLikelihood;
+}
+
+/******************************************************************************/
+
+void JointLikelihoodFunction::reportResults()
+{
+    // report character model parameters and likelihood
+    ParameterList parameters;
+
+    TransitionModel* characterModel = characterTreeLikelihood_->getModel();
+    parameters = characterModel->getParameters();
+    bool printToStd = false;
+    switch(optimizationScope_)
+    {
+        case none: 
+            break; 
+        case onlyCharacter:
+            break;
+        case onlySequence: 
+            printToStd = true;
+            break;
+        case both: 
+            printToStd = true;
+            break;
+        default:
+            throw Exception("Error! illegal hypothesis setting");
+    }
+    if (printToStd)
+    {
+        for (size_t i = 0; i < parameters.size(); i++)
+        {
+            ApplicationTools::displayResult(parameters[i].getName(), TextTools::toString(parameters[i].getValue()));
+        }
+    }
+    double charLogL = characterTreeLikelihood_->getValue();
+    ApplicationTools::displayResult("Character Log likelihood", TextTools::toString(-charLogL, 15));
+
+    // report sequence model paraneters
+    MixedSubstitutionModelSet* sequenceModel = dynamic_cast<MixedSubstitutionModelSet*>(sequenceTreeLikelihood_->getSubstitutionModelSet());
+    if (printToStd)
+    {
+        for (size_t m = 0; m < sequenceModel->getNumberOfModels(); ++m) 
+        {
+            ApplicationTools::displayMessage("\nmodel " + TextTools::toString(m+1) + "\n");
+            TransitionModel* model = sequenceModel->getModel(m);
+            parameters = model->getParameters();
+            for (size_t j = 0; j < parameters.size(); j++)
+            {
+                ApplicationTools::displayResult(parameters[j].getName(), TextTools::toString(parameters[j].getValue()));
+            }
+        }
+    }
+    double seqLogL = sequenceTreeLikelihood_->getValue();
+    ApplicationTools::displayResult("Sequence Log likelihood", TextTools::toString(-seqLogL, 15));
+
+    // report joint likelihood
+    double overallLogL = charLogL + seqLogL; // = log(charLikelihood * seqLikelihood)
+    logl_ = overallLogL;
+    ApplicationTools::displayResult("Overall Log likelihood", TextTools::toString(-overallLogL, 15));
+    cout << "\n" << endl;
+}
+
+/******************************************************************************/
+
+void JointLikelihoodFunction::optimizeSequenceModel()
+{
+    string paramValue;
+    try
+    {
+        paramValue = bppml_->getParam("sequence.optimization.method");
+    }
+    catch (exception& e)
+    {
+        paramValue = "D-BFGS(derivatives=Gradient,nstep=10)";
+    }
+    string paramsToIgnore;
+    switch(hypothesis_)
+    {
+        case null: 
+            paramsToIgnore = "BrLen,RELAX.k_1,RELAX.k_2";
+            break;      // k = 1 both in model1 (BG) and model2 (FG)
+        case alternative: 
+            paramsToIgnore = "BrLen,RELAX.k_1,RELAX.1_Full.theta_1,RELAX.1_Full.theta1_1,RELAX.1_Full.theta2_1,RELAX.2_Full.theta_1,RELAX.2_Full.theta1_1,RELAX.2_Full.theta2_1,RELAX.3_Full.theta_1,RELAX.3_Full.theta1_1,RELAX.3_Full.theta2_1"; // ignore frequency parameters to reduce optimization duration - results in one unit of ll reduction in optimality and 1 minutre reduction in duration
+            break;      // k = 1 only in model1 (BG)
+        default:
+            throw Exception("Error! illegal hypothesis setting");
+    }
+    bppml_->getParam("optimization.ignore_parameters") = paramsToIgnore;
+    PhylogeneticsApplicationTools::optimizeParameters(sequenceTreeLikelihood_, sequenceTreeLikelihood_->getParameters(), bppml_->getParams());
+}
+
+/******************************************************************************/
+
+void JointLikelihoodFunction::computeAlternativeJointLikelihood()
+{  
+    /* approximate the expected character history based on numOfMappings sampled stochastic mappings */
+    vector<Tree*> mappings;
+    stocMapping_->generateStochasticMapping(mappings);
+    Tree* expectedHistory = stocMapping_->generateExpectedMapping(mappings);
+
+    setPartitionByHistory(expectedHistory); // induce a partition of the tree based on the epxected character history
+
+    /* compute the likelihood of the sequence model */
+    updatesequenceTreeLikelihood(expectedHistory);
+
+    /* if needed, optimize the model */
+    switch(optimizationScope_)
+    {
+        case none: 
+            break;
+        case onlyCharacter: 
+            throw Exception("Error! There is no option to optimize only the character model during alternative model fitting"); 
+            break;
+        case onlySequence: 
+            optimizeSequenceModel(); 
+            break;
+        case both: 
+            throw Exception("Error! Attempt to violate the depedency between the chatacter model and sequnce model during alternative model fitting");
+        default:
+            throw Exception("Error! illegal optimizationScope setting");
+    }
+
+    reportResults();
+
+    /* free resources - now some of these parameters were defined localy - need to use friend functions otherwise can't free it */
+    size_t numOfMappings = mappings.size();
+    for (size_t h=0; h<numOfMappings; ++h)
+    {
+        delete mappings[h];
+    }
+    delete expectedHistory; // delete the expectedHistory, that was cloned via updatesequenceTreeLikelihood
+}
+
+/******************************************************************************/
+
+void JointLikelihoodFunction::optimizeCharacterModel()
+{
+        // fill in missing parameter for optimization in bppml_
+        string paramValue;
+        try
+        {
+            paramValue = bppml_->getParam("sequence.optimization.method");
+        }
+        catch (exception& e)
+        {
+            paramValue = "D-Brent(derivatives=Newton, nstep=10)";
+        }
+        bppml_->getParam("optimization.ignore_parameters") = "BrLen"; // branch lengths should always be ignored
+        PhylogeneticsApplicationTools::optimizeParameters(characterTreeLikelihood_, characterTreeLikelihood_->getParameters(), bppml_->getParams());
+}
+
+/******************************************************************************/
+
+void JointLikelihoodFunction::computeNullJointLikelihood()
+{
+    switch(optimizationScope_)
+    {
+        case none:
+            break;
+        case onlyCharacter: 
+            optimizeCharacterModel();
+            break;
+        case onlySequence: 
+            optimizeSequenceModel();
+            break;
+        case both:
+            // optimize the character model independetly of the sequence model
+            optimizeCharacterModel();
+
+            // optimize the sequence model with hypothesis_ (which is null, since computeNullJointLikelihood was called)
+            optimizeSequenceModel();
+            break;
+        default: 
+            throw Exception("Error! illegal optimizationScope setting");
+    }
+
+    reportResults();
+}

--- a/src/Bpp/Phyl/Likelihood/JointLikelihoodFunction.h
+++ b/src/Bpp/Phyl/Likelihood/JointLikelihoodFunction.h
@@ -1,0 +1,214 @@
+//
+// File: JointLikelihoodFunction.cpp
+// Created by: Keren Halabi
+// Created on: Thu Aug 28 13:14 2018
+//
+
+/*
+Copyright or © or Copr. Bio++ Development Team, (November 17, 2004)
+
+This software is a computer program whose purpose is to provide classes
+for numerical calculus. This file is part of the Bio++ project.
+
+This software is governed by the CeCILL  license under French law and
+abiding by the rules of distribution of free software.  You can  use, 
+modify and/ or redistribute the software under the terms of the CeCILL
+license as circulated by CEA, CNRS and INRIA at the following URL
+"http://www.cecill.info". 
+
+As a counterpart to the access to the source code and  rights to copy,
+modify and redistribute granted by the license, users are provided only
+with a limited warranty  and the software's author,  the holder of the
+economic rights,  and the successive licensors  have only  limited
+liability. 
+
+In this respect, the user's attention is drawn to the risks associated
+with loading,  using,  modifying and/or developing or reproducing the
+software by the user in light of its specific status of free software,
+that may mean  that it is complicated to manipulate,  and  that  also
+therefore means  that it is reserved for developers  and  experienced
+professionals having in-depth computer knowledge. Users are therefore
+encouraged to load and test the software's suitability as regards their
+requirements in conditions enabling the security of their systems and/or 
+data to be ensured and,  more generally, to use and operate it in the 
+same conditions as regards security. 
+
+The fact that you are presently reading this means that you have had
+knowledge of the CeCILL license and that you accept its terms.
+*/
+
+// for bpp-core
+#include <Bpp/Numeric/Function/Functions.h>
+#include <Bpp/Numeric/AbstractParametrizable.h>
+#include <Bpp/App/BppApplication.h>
+
+// From bpp-phyl:
+#include <Bpp/Phyl/Tree.h>
+#include <Bpp/Phyl/Likelihood/RHomogeneousTreeLikelihood.h>
+#include <Bpp/Phyl/Likelihood/RNonHomogeneousMixedTreeLikelihood.h>
+#include <Bpp/Phyl/Model/MixedSubstitutionModelSet.h>
+#include <Bpp/Phyl/Mapping/StochasticMapping.h>
+#include <Bpp/Phyl/Parsimony/DRTreeParsimonyScore.h>
+
+// From bpp-seq:
+#include <Bpp/Seq/Container/SiteContainer.h>
+#include <Bpp/Seq/Container/VectorSiteContainer.h>
+
+
+using namespace bpp;
+using namespace std;
+
+
+class JointLikelihoodFunction:
+  public Function,
+  public AbstractParametrizable
+{
+
+  public:
+    enum Hypothesis
+    {
+        null = 0,
+        alternative = 1
+    };
+
+    enum OptimizationScope 
+    { 
+      none=0, 
+      onlyCharacter=1, 
+      onlySequence=2, 
+      both=3 
+    };
+
+  private:
+    Hypothesis hypothesis_;
+    BppApplication* bppml_;
+    RHomogeneousTreeLikelihood* characterTreeLikelihood_; 
+    RNonHomogeneousMixedTreeLikelihood* sequenceTreeLikelihood_; 
+    StochasticMapping* stocMapping_;
+    OptimizationScope optimizationScope_;
+    double logl_;
+
+  public:
+
+    /* basic functions */
+
+    // base constrcutor - let it get the character model and character data for convenience - but it will create the treeLikelihood instance nad the sotchasticMapping instnace from the constructor
+    JointLikelihoodFunction(BppApplication* bppml, const Tree* tree, const VectorSiteContainer* characterData, TransitionModel* characterModel, const VectorSiteContainer* sequenceData, MixedSubstitutionModelSet* sequenceModel, DiscreteDistribution* rDist);
+
+    // copy constructor
+    JointLikelihoodFunction(const JointLikelihoodFunction& jlf):
+      AbstractParametrizable(""), 
+      hypothesis_(jlf.hypothesis_),
+      bppml_(jlf.bppml_),
+      characterTreeLikelihood_(jlf.characterTreeLikelihood_->clone()),
+      sequenceTreeLikelihood_(dynamic_cast<RNonHomogeneousMixedTreeLikelihood*>(jlf.sequenceTreeLikelihood_->clone())),
+      stocMapping_(jlf.stocMapping_->clone()),
+      optimizationScope_(jlf.optimizationScope_),
+      logl_(jlf.logl_)
+    { }
+
+    // assignment operator
+    JointLikelihoodFunction& operator=(const JointLikelihoodFunction& jlf)
+    {
+      hypothesis_ = jlf.hypothesis_;
+      bppml_ = jlf.bppml_;
+      characterTreeLikelihood_ = jlf.characterTreeLikelihood_->clone(); 
+      sequenceTreeLikelihood_ = dynamic_cast<RNonHomogeneousMixedTreeLikelihood*>(jlf.sequenceTreeLikelihood_->clone()); 
+      stocMapping_ = jlf.stocMapping_->clone();
+      optimizationScope_ = jlf.optimizationScope_;
+      logl_ = jlf.logl_;
+      return *this;
+    }
+
+    // destructor
+    ~JointLikelihoodFunction();
+
+    // clone operator
+    JointLikelihoodFunction* clone() const { return new JointLikelihoodFunction(*this); }
+    
+    /* basic Function methods */
+
+    /**
+     * @brief Set the paramters of the joint likelihood function according ot a given list of parameters
+     * 
+     * @param pl  A list of parameters whose value should be set inside the joint likelihood function 
+     */
+    void setParameters(const ParameterList& pl)
+    {
+      matchParametersValues(pl);
+    }
+    
+    /**
+     * @brief Return the last computed log likelihood
+     */
+    double getValue() const { return logl_; }
+
+    /**
+     * @brief Return the pointer to the character likelihood function
+     */
+    const HomogeneousTreeLikelihood* getCharacterLikelihoodFunction() const { return characterTreeLikelihood_; }
+
+    /**
+     * @brief Return the pointer to the sequence likelihood function
+     */
+    const RNonHomogeneousMixedTreeLikelihood* getSequenceLikelihoodFunction() const { return sequenceTreeLikelihood_; }
+ 
+    /**
+     * @brief Computes the value of the joint likelihood function depending on hypothesis - calls either computeNullJointLikelihood or computeAlternativeJointLikelihood
+     * 
+     * @param pl  A list of parameters whose value should be set inside the joint likelihood function 
+     */
+    void fireParameterChanged(const ParameterList& pl);
+
+    /* Auxiliary methods */
+
+    /**
+     * @brief Set the hypothesis data memeber (either null or alternative)
+     */
+    void setHypothesis(JointLikelihoodFunction::Hypothesis hypothesis) { hypothesis_ = hypothesis; }
+
+    /**
+     * @brief Set the hypothesis data memeber (none / onlyCharacter / onlySequence / both)
+     */
+    void setOptimizationScope(JointLikelihoodFunction::OptimizationScope optimizationScope) { optimizationScope_ = optimizationScope; }
+
+    /**
+     * @brief Defines the tree partition into the two sub-models of the sequence model according to a given history
+     * 
+     * @param history  A tree in which each node has a state propetly assinged to it, corresponding to its binary character state
+     */
+    void setPartitionByHistory(const Tree* history);
+
+    /**
+     * @brief replaced the instnace of sequwnce tree likelihood so that the updated instance will consider the new character history
+     * 
+     * @param history  A tree in which each node has a state propetly assinged to it, corresponding to its binary character state
+     */
+    void updatesequenceTreeLikelihood(const Tree* history);
+
+    /**
+     * @brief Computes the joint likelihood function given the null model (that is, no change in selective pressure along the phylogeny, regardless of the character history)
+     */
+    void computeNullJointLikelihood();
+    
+    /**
+     * @brief Computes the joint likelihood function given the null model (that is, change in selective pressure along the phylogeny depending on the character history)
+     */
+    void computeAlternativeJointLikelihood();
+
+    /**
+     * @brief Optimizes the parameters of the character model
+     */
+    void optimizeCharacterModel();
+
+    /**
+     * @brief Optimizes the parameters of the sequence model
+     */
+    void optimizeSequenceModel();
+
+    /**
+     * @brief Reports the joint model paramerers to std and updates the logl_ data member
+     */
+    void reportResults();
+
+};

--- a/src/Bpp/Phyl/Mapping/StochasticMapping.cpp
+++ b/src/Bpp/Phyl/Mapping/StochasticMapping.cpp
@@ -1,0 +1,524 @@
+#include "StochasticMapping.h"
+#include "../Likelihood/TreeLikelihoodTools.h"
+#include "../Likelihood/TreeLikelihood.h"
+#include "../Simulation/MutationProcess.h"
+#include "../Node.h"
+#include "../App/PhylogeneticsApplicationTools.h"
+#include "../Io/Newick.h"
+#include "../TreeIterator.h"
+
+#include <Bpp/Text/TextTools.h>
+#include <Bpp/App/ApplicationTools.h>
+#include <Bpp/Numeric/Number.h>
+#include <Bpp/Numeric/Random/RandomTools.h>
+
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+
+using namespace bpp;
+
+using namespace std;
+
+#define STATE "state"
+
+/******************************************************************************/
+
+StochasticMapping::StochasticMapping(const TreeLikelihood* tl, size_t numOfMappings):
+    mappingParameters_(),
+    baseTree_(),
+    tl_(),
+    ConditionalProbabilities_(),
+    nodesCounter_(0),
+    numOfMappings_(numOfMappings)
+{
+    tl_ = tl;
+    baseTree_ = tl_->getTree().clone();                      // this calls clone - but for some reason upson deletion a segnetation fault occurs
+    giveNamesToInternalNodes(baseTree_);                     // set names for the internal nodes of the tree, in case of absence                       
+    const SubstitutionModel* model = dynamic_cast<const SubstitutionModel*>(tl_->getModelForSite(0,0));
+    mappingParameters_ = new SimpleMutationProcess(model);   // the procedure assumes that the same model applies to all the branches of the tree
+    ComputeConditionals();                                               
+}
+
+/******************************************************************************/
+
+StochasticMapping::~StochasticMapping()
+{
+    if (mappingParameters_) delete mappingParameters_;
+    if (baseTree_) delete baseTree_; // delete the cloned base tree
+}
+
+/******************************************************************************/
+
+void StochasticMapping::generateStochasticMapping(vector<Tree*>& mappings) 
+{
+ 
+    for (size_t i=0; i<numOfMappings_; ++i)
+    {
+        // clone the base tree to acheive the skeleton in which the mapping will be represented
+        Tree* mapping = baseTree_->clone();
+        setLeafsStates(mapping);
+        
+        /* step 2: simulate a set of ancestral states, based on the fractional likelihoods from step 1 */
+        sampleAncestrals(mapping);
+
+        /* step 3: simulate mutational history of each lineage of the phylogeny, conditional on the ancestral states */
+        sampleMutationsGivenAncestrals(mapping);
+
+        // add the mapping to the vector of mapping
+        mappings.push_back(mapping);
+    }
+}
+
+/******************************************************************************/
+
+void StochasticMapping::setExpectedAncestrals(Tree* expectedMapping)
+{
+    TreeTemplate<Node>* ttree = dynamic_cast<TreeTemplate<Node>*>(expectedMapping); 
+    PreOrderTreeIterator* treeIt = new PreOrderTreeIterator(*ttree);
+    for (Node* node = treeIt->begin(); node != treeIt->end(); node = treeIt->next()) {
+        if (!node->isLeaf()) {
+            int nodeId = node->getId();
+            if (!node->hasFather())
+            {
+                size_t rootState = distance(ConditionalProbabilities_[nodeId][0].begin(), max_element(ConditionalProbabilities_[nodeId][0].begin(), ConditionalProbabilities_[nodeId][0].end()));
+                setNodeState(node,rootState);
+            }
+            else
+            {
+                int fatherState = getNodeState(node->getFather());
+                size_t sonState = distance(ConditionalProbabilities_[nodeId][fatherState].begin(), max_element(ConditionalProbabilities_[nodeId][fatherState].begin(), ConditionalProbabilities_[nodeId][fatherState].end()));
+                setNodeState(node,sonState); // in the case of a leaf, the assigned state must be sampled
+            }
+        }
+	}
+    delete(treeIt);
+}
+
+/******************************************************************************/
+
+Tree* StochasticMapping::generateExpectedMapping(vector<Tree*>& mappings, size_t divMethod)
+{
+    // initialize the expected history
+    nodesCounter_ = dynamic_cast<TreeTemplate<Node>*>(baseTree_)->getNodes().size()-1;
+    Tree* expectedMapping = baseTree_->clone();
+    setLeafsStates(expectedMapping);
+    
+    // set the ancestral states accrdonig to the maximal posterior (i.e, conditional) probability
+    setExpectedAncestrals(expectedMapping);
+    
+    // update the expected history with the dwelling times
+    size_t statesNum = tl_->getNumberOfStates();
+    vector<Node*> nodes = (dynamic_cast<TreeTemplate<Node>*>(expectedMapping))->getNodes(); // get all the base nodes in post order ahead (as a post order iterator would also encounter nodes that are added during the procedure)
+    for (size_t n=0; n< nodes.size(); ++n) {
+        Node* node = nodes[n];
+        if (node->hasFather()) // for any node except to the root
+            {
+            // initialize vector of average dwelling times for the branch stemming from node
+            VDouble AverageDwellingTimes;
+            AverageDwellingTimes.clear();
+            AverageDwellingTimes.resize(statesNum,0);
+            // compute the average dwelling times of all the states
+            for (size_t i=0; i<mappings.size(); ++i)
+            {
+                TreeTemplate<Node>* mapping =  dynamic_cast<TreeTemplate<Node>*>(mappings[i]);
+                // get the pointers to the node and its father in the i'th mapping
+                Node* curNode = mapping->getNode(node->getName());
+                Node* father = mapping->getNode(node->getFather()->getName()); // the original father of the node (according to the base tree) in the mapping
+                while (curNode != father)
+                {
+                    AverageDwellingTimes[getNodeState(curNode)] += curNode->getDistanceToFather();
+                    curNode = curNode->getFather();
+                }
+            }
+            double branchLength = node->getDistanceToFather();   // this is the length of the original branch in the base tree
+            bool updateBranch = true;
+            for (size_t state=0; state<statesNum; ++state)
+            {
+                AverageDwellingTimes[state] /= static_cast<double>(mappings.size());
+                if (AverageDwellingTimes[state] == branchLength) // if one of the dwelling times equals the branch length, then there is only one state along te branch and there is no need to edit it
+                {
+                    updateBranch = false;
+                }  
+            }
+            // break the branch according to average dwelling times
+            if (updateBranch)
+            {
+                updateBranchByDwellingTimes(node, AverageDwellingTimes, divMethod);
+            }
+        }
+    }
+    return expectedMapping;
+}
+
+/******************************************************************************/
+
+int StochasticMapping::getNodeState(const Node* node) const
+{
+    return (dynamic_cast<const BppInteger*>(node->getNodeProperty(STATE)))->getValue();
+}
+
+/******************************************************************************/
+
+void StochasticMapping::setNodeState(Node* node, size_t state)
+{
+    node->setNodeProperty(STATE,BppInteger(static_cast<int>(state)));
+}
+
+/******************************************************************************/
+
+void StochasticMapping::giveNamesToInternalNodes(Tree* tree)
+{
+    TreeTemplate<Node>* ttree = dynamic_cast<TreeTemplate<Node>*>(tree);
+    vector<Node*> nodes = ttree->getNodes();
+    for (size_t i=0; i<nodes.size(); ++i) {
+        if (!nodes[i]->hasName())
+            nodes[i]->setName("_baseInternal_" + TextTools::toString(nodes[i]->getId()));
+    }  
+}
+
+/******************************************************************************/
+
+void StochasticMapping::setLeafsStates(Tree* mapping)
+{
+    const SiteContainer* leafsStates = tl_->getData();
+    TreeTemplate<Node>* ttree = dynamic_cast<TreeTemplate<Node>*>(mapping); 
+    vector<Node*> nodes = ttree->getNodes();
+
+    for (size_t i=0; i<nodes.size(); ++i)
+    {
+        if (nodes[i]->isLeaf()) {
+            string nodeName = nodes[i]->getName();
+            size_t leafState = static_cast<int>(tl_->getAlphabetStateAsInt(leafsStates->getSequence(nodeName).getValue(0)));
+            setNodeState(nodes[i],leafState);
+        }
+    }
+}
+
+/******************************************************************************/
+
+void StochasticMapping::computeFractionals(VVDouble& fractionalProbabilities)
+{
+    // some auxiliiary variables
+    size_t statesNum = tl_->getNumberOfStates();
+    const TransitionModel* model = tl_->getModelForSite(0,0); // this calls assumes that all the sites and all the branches are assoiacted with the same node
+    const SiteContainer* leafsStates = tl_->getData();
+    TreeTemplate<Node>* ttree = dynamic_cast<TreeTemplate<Node>*>(baseTree_); 
+    vector<Node*> nodes = ttree->getNodes();
+
+    // compute the fractional probabilities according to Felsenstein prunnig algorithm: for each node nodes[i] and state s compute: P(Data[leafs under node[i]]|node[i] has state s] 
+    for (size_t i=0; i<nodes.size(); ++i) // traverse the tree in post-order
+    {
+        int nodeId = nodes[i]->getId();
+        string nodeName = nodes[i]->getName();
+        if (nodes[i]->isLeaf()) // if the node is a leaf, set the fractional probability of its state to 1, and the rest ot 0
+        {
+            size_t leafState = static_cast<int>(tl_->getAlphabetStateAsInt(leafsStates->getSequence(nodeName).getValue(0)));
+            for (size_t nodeState=0; nodeState<statesNum; ++nodeState)
+		    {
+                if (nodeState != leafState)
+                {
+                    fractionalProbabilities[nodeId][nodeState] = 0;
+                }
+                else {
+                    fractionalProbabilities[nodeId][nodeState] = 1; 
+                }
+            }   
+        }
+        else                // if the node is internal, follow the Felesenstein computation rule to compute the fractional probability
+        {   
+            for (size_t nodeState=0; nodeState<statesNum; ++nodeState)
+		    {
+                double fullProb = 1;
+                for (size_t j=0; j<(nodes[i]->getNumberOfSons()); ++j) // for each son of the node, sum over the probabilities of all its assignments given its father's state (i.e, nodeState)
+                {
+                    double sonProb = 0;
+                    double bl = nodes[i]->getSon(j)->getDistanceToFather();
+                    for(size_t sonState=0; sonState<statesNum; ++sonState)
+                    {
+                        sonProb += model->Pij_t(nodeState, sonState, bl) * fractionalProbabilities[nodes[i]->getSon(j)->getId()][sonState];
+                    }
+                    fullProb *= sonProb;
+                }
+                fractionalProbabilities[nodeId][nodeState] = fullProb;
+            }
+		}
+    }
+}
+
+/******************************************************************************/
+
+void StochasticMapping::ComputeConditionals()
+{
+    // some auxiliiary variables
+    size_t statesNum = tl_->getNumberOfStates();
+    VDouble rootProbabilities = tl_->getRootFrequencies(0); 
+    const TransitionModel* model = tl_->getModelForSite(0,0);
+    TreeTemplate<Node>* ttree = dynamic_cast<TreeTemplate<Node>*>(baseTree_); 
+    vector<Node*> nodes = ttree->getNodes(); // here - how many nodes? only 4! what happened?
+
+    /* compute the fractional probabilities for each node and state */
+    VVDouble fractionalProbabilities;
+    fractionalProbabilities.clear();
+    fractionalProbabilities.resize(nodes.size(), VDouble(statesNum));
+    computeFractionals(fractionalProbabilities);
+    
+    /*  compute the conditional probabilities: for each combination of nodes son, father, compute Pr(son recieves sonState | father has fatherState) */
+    ConditionalProbabilities_.clear();
+    ConditionalProbabilities_.resize((nodes.size()));
+    
+    for (size_t i=0; i<nodes.size(); ++i)
+    {
+        if (!nodes[i]->isLeaf() || !nodes[i]->hasFather()) { // the second condition will catch the root even if it has a single child (in which case, isLeaf() returns true)
+            int nodeId = nodes[i]->getId();
+            ConditionalProbabilities_[nodes[i]->getId()].resize(statesNum, VDouble(statesNum)); // use aux variable numOfStates
+            if (!(nodes[i]->hasFather())) { // if the node is the root -> set the conditional probability to be same for all "fatherStates"
+                double sum = 0.0;
+                for (size_t sonState=0; sonState<statesNum; ++sonState)
+                {
+                    double stateConditionalNominator = fractionalProbabilities[nodeId][sonState] * rootProbabilities[sonState];
+                    for (size_t fatherState=0; fatherState<statesNum; ++fatherState)
+                        ConditionalProbabilities_[nodeId][fatherState][sonState] = stateConditionalNominator;
+                    sum += stateConditionalNominator;
+                }
+                for (size_t fatherState=0; fatherState<statesNum; ++fatherState)
+                {
+                    for (size_t sonState=0; sonState<statesNum; ++sonState)
+                        ConditionalProbabilities_[nodeId][fatherState][sonState] /= sum;
+                }
+            }
+            else {                          // else -> follfow equation (10) from the paper to compute the consitional assingment probabilities given the ones of his father
+                for (size_t fatherState=0; fatherState<statesNum; ++fatherState)
+                {
+                    double sum = 0.0; 
+                    for (size_t sonState=0; sonState<statesNum; ++sonState)
+                    {
+                        double stateConditionalNominator = fractionalProbabilities[nodes[i]->getFatherId()][fatherState] * model->Pij_t(fatherState,sonState,nodes[i]->getDistanceToFather());
+                        ConditionalProbabilities_[nodeId][fatherState][sonState] = stateConditionalNominator;
+                        sum += stateConditionalNominator;
+                    }
+                    for (size_t sonState=0; sonState<statesNum; ++sonState)
+                        ConditionalProbabilities_[nodeId][fatherState][sonState] /= sum;
+                }
+            }
+        }
+    }
+}
+
+/******************************************************************************/
+
+size_t StochasticMapping::sampleState(const VDouble& distibution)
+{
+    size_t state=0;        // the default state is 0
+    double prob = RandomTools::giveRandomNumberBetweenZeroAndEntry(1.0);
+
+    for (size_t i=0; i<distibution.size(); ++i) {
+        prob-=distibution[i];
+        if (prob < 0) { // if the the sampled probability is smaller than the probability to choose state i -> set state to be i
+            state = i; 
+            break;
+        }
+    }
+    return state;
+}
+
+/******************************************************************************/
+
+void StochasticMapping::sampleAncestrals(Tree* mapping)
+{
+    TreeTemplate<Node>* ttree = dynamic_cast<TreeTemplate<Node>*>(mapping); 
+    PreOrderTreeIterator* treeIt = new PreOrderTreeIterator(*ttree);
+    for (Node* node = treeIt->begin(); node != treeIt->end(); node = treeIt->next()) {
+        if (!node->isLeaf()) {
+            int nodeId = node->getId();
+            if (!node->hasFather())
+            {
+                size_t rootState = sampleState(ConditionalProbabilities_[nodeId][0]); // set father state to 0 (all the entries in the fatherState level are the same anyway)
+                setNodeState(node,rootState);
+            }
+            else
+            {
+                int fatherState = getNodeState(node->getFather());
+                size_t sonState = sampleState(ConditionalProbabilities_[nodeId][fatherState]);
+                setNodeState(node,sonState); // in the case of a leaf, the assigned state must be sampled
+            }
+        }
+	}
+    delete(treeIt);
+}
+
+/******************************************************************************/
+
+void StochasticMapping::sampleMutationsGivenAncestrals(Tree* mapping) 
+{
+    TreeTemplate<Node>* ttree = dynamic_cast<TreeTemplate<Node>*>(mapping); 
+    vector<Node*> nodes = ttree->getNodes();
+    nodesCounter_ = nodes.size()-1; // intialize nodesCounter_ according ot the number of nodes in the base tree
+    for (size_t i=0; i <nodes.size(); ++i)
+    {
+        
+        Node* son = nodes[i];
+        if (son->hasFather()) {
+            sampleMutationsGivenAncestralsPerBranch(son);
+        }
+    }
+}
+
+/******************************************************************************/
+
+void StochasticMapping::updateBranchMapping(Node* son, const MutationPath& branchMapping)
+{  
+    const vector<size_t> states = branchMapping.getStates();
+    const VDouble times = branchMapping.getTimes();
+    Node* curNode = son;
+    Node* nextNode;
+    int eventsNum = static_cast<int>(branchMapping.getNumberOfEvents());
+    
+    if (eventsNum == 0) // if there are no events >-return nothing
+        return;
+    else
+    {
+        for (int i=eventsNum-1; i>-1; --i) { // add a new node to represent the transition
+            nodesCounter_ += 1;
+            const string name = "_mappingInternal" + TextTools::toString(nodesCounter_) + "_";
+            nextNode = new Node(static_cast<int>(nodesCounter_), name);
+            setNodeState(nextNode,states[i]);
+            nextNode->setDistanceToFather(times[i]);
+            
+            // set the father to no longer be the father of curNode
+            Node* originalFather = curNode->getFather();
+            originalFather->removeSon(curNode); // also removes originalFather as the father of curNode
+            // set nextNode to be the new father of curNode
+            curNode->setFather(nextNode); // also adds curNode to the sons of nextNode
+            // set curNode's original father ot be the father of nextNode
+            nextNode->setFather(originalFather); // also adds nextNode to the sons of originalFather - or not? make sure this is the father at all times
+            curNode = nextNode;
+        }
+        return;
+    }
+}
+
+/******************************************************************************/
+
+void StochasticMapping::sampleMutationsGivenAncestralsPerBranch(Node* son, size_t maxIterNum)
+{
+    Node* father = son->getFather();
+    double branchLength = son->getDistanceToFather();
+    size_t fatherState = getNodeState(father); 
+    size_t sonState = getNodeState(son);
+
+    /* simulate mapping on a branch until you manage to finish at the son's state */
+	for (size_t i = 0; i < maxIterNum; ++i) 
+	{
+		double disFromNode = 0.0;
+		size_t curState = fatherState;
+        MutationPath tryMapping(mappingParameters_->getSubstitutionModel()->getAlphabet(), fatherState, branchLength);
+
+		double timeTillChange;
+        // if the father's state is not the same as the son's state -> use the correction corresponding to equation (11) in the paper
+        if (fatherState != sonState)
+		{   // sample timeTillChange conditional on it being smaller than branchLength
+			double u = RandomTools::giveRandomNumberBetweenZeroAndEntry(1.0);
+            double waitingTimeParam = -1 * mappingParameters_->getSubstitutionModel()->Qij(fatherState, fatherState); // get the parameter for the exoponential distribution to draw the waiting time from
+            double tmp = u * (1.0 - exp(branchLength * -waitingTimeParam));
+            timeTillChange =  -log(1.0 - tmp) / waitingTimeParam;
+            assert (timeTillChange < branchLength);
+		} else {
+            timeTillChange = mappingParameters_->getTimeBeforeNextMutationEvent(fatherState); // draw the time until a transition from exponential distribution with the rate of leaving fatherState   
+        }
+        
+		while (disFromNode + timeTillChange < branchLength)  // a jump occured but not passed the whole branch -> 
+		{
+            tryMapping.addEvent(curState, timeTillChange);                                        // add the current state and time to branch history
+			
+            disFromNode += timeTillChange;			
+            timeTillChange = mappingParameters_->getTimeBeforeNextMutationEvent(curState);        // draw the time until a transition from exponential distribution with the rate of leaving curState
+       	    curState = mappingParameters_->mutate(curState);                                      // draw the state to transition to after from initial state curState based on the relative tranistion rates distribution (see MutationProcess.cpp line 50)	
+        }
+		// the last jump passed the length of the branch -> finish the simulation and check if it's sucessfull (i.e, mapping is finished at the son's state)
+		if (curState != sonState) // if the simulation failed, try again
+		{      
+			continue;
+		}
+		else                      // if the simulation was sucessfully, add it to the build mapping
+		{
+			double timeOfJump = branchLength - disFromNode;
+            son->setDistanceToFather(timeOfJump);
+            updateBranchMapping(son, tryMapping);     // add the successfull simulation to the build mapping
+            return;
+		}
+	}
+	// if all simulations failed -> throw an exception
+    throw Exception("could not produce simulations with father = " + TextTools::toString(fatherState) + " son " + TextTools::toString(sonState) + " branch length = " + TextTools::toString(branchLength));
+}
+
+/******************************************************************************/
+
+void StochasticMapping::updateBranchByDwellingTimes(Node* node, VDouble& dwellingTimes, size_t divMethod)
+{
+    /* first, convert the dwelling times vector to a mutation path of the branch */
+    size_t statesNum = tl_->getNumberOfStates();
+    size_t sonState = getNodeState(node);
+    size_t fatherState = getNodeState(node->getFather());
+    double branchLength = node->getDistanceToFather();
+    double Pf = 1;
+    double Ps = 1;
+    MutationPath branchMapping(mappingParameters_->getSubstitutionModel()->getAlphabet(), fatherState, branchLength);
+    // set the first event with the dwelling time that matches the state of the father
+    if (fatherState == sonState)
+    {
+        if (divMethod == 0) // here - do what Itay suggested
+        {
+            int ancestorState = 0;
+            if (node->getFather()->hasFather())
+            {
+                ancestorState = getNodeState(node->getFather()->getFather());
+            }
+            if (node->hasFather())
+            {
+                Pf = ConditionalProbabilities_[node->getFather()->getId()][ancestorState][fatherState]; // segmentation fault on node id 30
+            }
+            Pf = Ps = 1;
+            if (!node->isLeaf())
+            {
+                Ps = ConditionalProbabilities_[node->getId()][fatherState][sonState];
+            }
+            branchMapping.addEvent(fatherState, dwellingTimes[fatherState]*(Pf/(Pf+Ps)));
+        }
+        else
+        {
+            branchMapping.addEvent(fatherState, 0);
+        }
+    }
+    else
+    {
+         branchMapping.addEvent(fatherState, dwellingTimes[fatherState]);
+    }
+    // set all events except for the one entering the son
+    for (size_t state=0; state<statesNum; ++state)
+    {
+        if (state != fatherState && state != sonState && dwellingTimes[state] > 0) // if the state matches an event which is not the first or the last -> add it
+        {
+            branchMapping.addEvent(state, dwellingTimes[state]);
+        }  
+    }
+    // change the length of the branch whose bottom node is the son according to the dwelling time of the relevant state
+    if (fatherState == sonState)
+    {
+        if (divMethod == 0)
+        {
+            node->setDistanceToFather(dwellingTimes[sonState]*(Ps/(Pf+Ps)));
+        }
+        else
+        {
+            node->setDistanceToFather(dwellingTimes[sonState]);
+        }
+    }
+    else
+    {
+        node->setDistanceToFather(dwellingTimes[sonState]);
+    }
+    
+    /* secondly, update the expected history with the dwelling times-based mutation path */
+    updateBranchMapping(node, branchMapping); 
+}

--- a/src/Bpp/Phyl/Mapping/StochasticMapping.h
+++ b/src/Bpp/Phyl/Mapping/StochasticMapping.h
@@ -1,0 +1,198 @@
+//
+// File: StochasticMapping.h
+// Created by: Keren Halabi
+// Created on: June 2018
+//
+
+/*
+  Copyright or © or Copr. CNRS, (November 16, 2004)
+
+  This software is a computer program whose purpose is to provide classes
+  for phylogenetic data analysis.
+
+  This software is governed by the CeCILL  license under French law and
+  abiding by the rules of distribution of free software.  You can  use, 
+  modify and/ or redistribute the software under the terms of the CeCILL
+  license as circulated by CEA, CNRS and INRIA at the following URL
+  "http://www.cecill.info". 
+
+  As a counterpart to the access to the source code and  rights to copy,
+  modify and redistribute granted by the license, users are provided only
+  with a limited warranty  and the software's author,  the holder of the
+  economic rights,  and the successive licensors  have only  limited
+  liability. 
+
+  In this respect, the user's attention is drawn to the risks associated
+  with loading,  using,  modifying and/or developing or reproducing the
+  software by the user in light of its specific status of free software,
+  that may mean  that it is complicated to manipulate,  and  that  also
+  therefore means  that it is reserved for developers  and  experienced
+  professionals having in-depth computer knowledge. Users are therefore
+  encouraged to load and test the software's suitability as regards their
+  requirements in conditions enabling the security of their systems and/or 
+  data to be ensured and,  more generally, to use and operate it in the 
+  same conditions as regards security. 
+
+  The fact that you are presently reading this means that you have had
+  knowledge of the CeCILL license and that you accept its terms.
+*/
+
+#ifndef ___STOCHASTIC_MAPPING_H
+#define ___STOCHASTIC_MAPPING_H
+
+#include "../Likelihood/TreeLikelihood.h"
+#include "../Simulation/MutationProcess.h"
+
+// From the STL:
+#include <iostream>
+#include <iomanip>
+
+using namespace std;
+
+typedef vector<vector<vector<double>>> VVVDouble;
+typedef vector<vector<double>> VVDouble;
+typedef vector<double> VDouble;
+
+/* class for reprenting the framework of Stochastic mapping
+   A StochasticMapping instance can be used to sample histories of state transitions along a tree, given a substitution model and the states at the tip taxa
+   For more information, see: Nielsen, Rasmus. "Mapping mutations on phylogenies." Systematic biology 51.5 (2002): 729-739.‏ */
+
+namespace bpp
+{
+    class StochasticMapping
+    {
+        protected:
+        const SimpleMutationProcess* mappingParameters_; // this instance will hold the parameters required for the sotchastic mapping procedure, and be used to generate stochastic mappings
+        Tree* baseTree_;                                 // this is the base tree, which will act as the skeleton of each induced mapping in the procedure
+        const TreeLikelihood* tl_;                       // the tree likelihood instance is used for computing the the conditional sampling probabilities of the ancestral states as well as the root assignment probabilities 
+        VVVDouble ConditionalProbabilities_;             // vector that holds the conditionl states assignment probabilities of the nodes in the tree (node*father_states*son_states)
+        size_t nodesCounter_;                            // counter of nodes hat allows adding unique names to the generated nodes while breaking branching in a mapping
+        size_t numOfMappings_;                           // the number of stochastic mappings to generate
+
+        public:
+
+        /* constructors and destructors */
+
+        explicit StochasticMapping(const TreeLikelihood* tl, size_t numOfMappings=10000); // it is a good general practice to use "explicit" keyword on constructors with a single argument: https://stackoverflow.com/questions/121162/what-does-the-explicit-keyword-mean
+
+        ~StochasticMapping();
+
+        StochasticMapping(const StochasticMapping& sm): // must pass sm by repference to avoid infinitie recusion in the copy construcor
+        mappingParameters_(sm.mappingParameters_),baseTree_(0),tl_(sm.tl_),ConditionalProbabilities_(sm.ConditionalProbabilities_),nodesCounter_(0), numOfMappings_(sm.numOfMappings_)
+        { baseTree_=sm.baseTree_->clone(); } // the tree must be cloned so that instead of copying the pointer to the tree, a new tree with a new pointer will be created
+
+        /**
+        * @brief Assignment operator
+        */
+        StochasticMapping& operator=(const StochasticMapping& sm)
+        {
+            tl_ = sm.tl_;
+            baseTree_ = sm.baseTree_->clone();
+            mappingParameters_ = sm.mappingParameters_;
+            ConditionalProbabilities_ = sm.ConditionalProbabilities_;  
+            numOfMappings_ = sm.numOfMappings_;
+            return *this;
+        }
+
+        /**
+         * @cloning function used by the copy constructor of ./Likelihood/JointLikelihoodFunction/h
+        */
+        StochasticMapping* clone() const { return new StochasticMapping(*this); }
+
+        
+        /* generates a stochastic mappings based on the sampling parameters 
+         * @param     Number of histories to sample
+         * @param mappings          Vector of Tree pointers that will hold the sampled stochastic mappings.
+         *                          Note that this function generates new tree instances, that must be deleted by the calling function.
+        */
+        void generateStochasticMapping(vector<Tree*>& mappings);
+
+        /* creates a single expected (i.e, average) history based on a given set of mappings
+         * steps correspond to Nielsen, Rasmus. "Mapping mutations on phylogenies." Systematic biology 51.5 (2002): 729-739.‏
+         * the function assumes that there is only one site to simulate history for */
+        /* @param mappings          A vector of stochastic mappings to average
+           @param divMethod         The method used in the case that the son and father share the same state (either divide the wdelling time of the staed state by 2 for  two transitions (method 0) or allocate the entire dwelling time to be adjacent to the son(method 1))
+         * @param mapping           A tree pointer that will hold the expected mapping.
+         *                          Note that this function generates a new tree instance, that must be deleted by the calling function.
+        */        
+        Tree* generateExpectedMapping(vector<Tree*>& mappings, size_t divMethod=0);
+
+        /* extracts the state of a node in a mapping 
+         * @param node              The node to get the state of
+         * @return                  Node state is int
+        */
+        int getNodeState(const Node* node) const;
+
+        private:
+
+        /* adds names to the internal nodes, in case of absence.
+         * @param tree               The tree whose nodes should be edited if needed.
+        */
+       void giveNamesToInternalNodes(Tree* tree);
+
+        /* sets the state of a node in a mapping 
+         * @param node               The node to get the state of
+         * @param state              The state that needs to be assigned to the node
+        */
+        void setNodeState(Node* node, size_t state);
+
+        /* set the character states of the leafs as properties of thier nodes instances
+         * @param mapping - the tree to sets the properties in
+        */
+        void setLeafsStates(Tree* mapping);
+        
+        /* compute the fractional probabilities of all the nodes assignements
+        * @param                     A vector of the fractional probabilities probabilities to fill in (node**state combinaion in each entry)
+       */       
+       void computeFractionals(VVDouble& fractionalProbabilities);
+       
+       /* compute the conditional probabilities of all the nodes assignments
+        * @param rootProbabilities  The root frequencies
+       */
+        void ComputeConditionals();
+
+        /* auxiliary function that samples a state based on a given discrete distribution
+         * @param distibution       The distribution to sample states based on
+        */
+        size_t sampleState(const VDouble& distibution); // k: best by ref
+        
+        /* samples ancestral states based on the conditional probabilities at each node in the base (user input) tree and the root assignment probabilities. States will be updated as nodes properties
+         * @param mapping               The tree whose nodes names should be updated according to their assigned states.
+        */   
+        void sampleAncestrals(Tree* mapping);
+
+        /* set ancestral states in the expected history based on the conditional probabilities at each node in the base (user input) tree and the root assignment probabilities. States will be updated as nodes properties
+         * @param expectedMapping       The expected mapping instance whose nodes names should be updated according to their assigned states.
+        */   
+        void setExpectedAncestrals(Tree* expectedMapping);
+
+        /* simulates mutations on phylogeny based the sampled ancestrals, tips data, and the simulation parameters
+         * @param mapping               The tree that should be edited according to the sampled history
+        */
+        void sampleMutationsGivenAncestrals(Tree* mapping); 
+
+        /* adds a branch mapping to the mapping in a tree format by repeatedly braking branches and adding internal nodes with single children
+         * @param son                   The node at the bottom of the branch
+         * @param branchMapping         The branchMapping of transitions in a MutationProcess format
+        */           
+        void updateBranchMapping(Node* son, const MutationPath& branchMapping);
+
+        /* sample mutations based on the stochastic mapping parameters, the source and destination state, and the branch length, and updates the simulated history along the branch in the input tree, on the fly
+         * @param son                   Node of interest
+         * @param maxIterNum            Maximal number of imulation trials
+        */   
+        void sampleMutationsGivenAncestralsPerBranch(Node* son, size_t maxIterNum = 10000);
+
+        /* converts a vector of dwelling times to a mutation path and then updates the bracnh stemming from the given node */
+        /* @param node              the node at the bottom of the branch
+         * @param dwellingTimes     A vector of dwelling times where the value at each entry i corresponds to the dwelling time under the i'th state
+         *                          Note that this function generates a new tree instance, that must be deleted by the calling function.
+           @param divMethod         The method used in the case that the son and father share the same state (either divide the wdelling time of the staed state by 2 for  two transitions (method 0) or allocate the entire dwelling time to be adjacent to the son(method 1))
+        */
+        void updateBranchByDwellingTimes(Node* node, VDouble& dwellingTimes, size_t divMethod=0);
+    };
+
+
+}
+
+#endif // ___STOCHASTIC_MAPPING_H

--- a/src/Bpp/Phyl/Model/Codon/RELAX.cpp
+++ b/src/Bpp/Phyl/Model/Codon/RELAX.cpp
@@ -1,0 +1,208 @@
+//
+// File: RELAX.cpp
+// Created by:  Keren Halabi
+// Created on: August 2018
+//
+
+/*
+   Copyright or © or Copr. Bio++ Development Team, (November 16, 2004)
+   This software is a computer program whose purpose is to provide classes
+   for phylogenetic data analysis.
+
+   This software is governed by the CeCILL  license under French law and
+   abiding by the rules of distribution of free software.  You can  use,
+   modify and/ or redistribute the software under the terms of the CeCILL
+   license as circulated by CEA, CNRS and INRIA at the following URL
+   "http://www.cecill.info".
+
+   As a counterpart to the access to the source code and  rights to copy,
+   modify and redistribute granted by the license, users are provided only
+   with a limited warranty  and the software's author,  the holder of the
+   economic rights,  and the successive licensors  have only  limited
+   liability.
+
+   In this respect, the user's attention is drawn to the risks associated
+   with loading,  using,  modifying and/or developing or reproducing the
+   software by the user in light of its specific status of free software,
+   that may mean  that it is complicated to manipulate,  and  that  also
+   therefore means  that it is reserved for developers  and  experienced
+   professionals having in-depth computer knowledge. Users are therefore
+   encouraged to load and test the software's suitability as regards their
+   requirements in conditions enabling the security of their systems and/or
+   data to be ensured and,  more generally, to use and operate it in the
+   same conditions as regards security.
+
+   The fact that you are presently reading this means that you have had
+   knowledge of the CeCILL license and that you accept its terms.
+ */
+
+#include "RELAX.h"
+#include <Bpp/Phyl/Model/Codon/YN98.h>
+#include <Bpp/Phyl/Model/MixtureOfASubstitutionModel.h>
+#include <math.h>                     /* pow */
+
+#include <Bpp/Numeric/NumConstants.h>
+#include <Bpp/Numeric/Prob/SimpleDiscreteDistribution.h>
+#include <Bpp/Numeric/AutoParameter.h>
+
+using namespace bpp;
+
+using namespace std;
+
+/******************************************************************************/
+
+RELAX::RELAX(const GeneticCode* gc, FrequenciesSet* codonFreqs) :
+  YNGP_M("RELAX.") // RELAX currenly inherits from YNGP_M as well, since it uses kappa and instead of the 5 GTR parameters
+{
+
+  // set the initial omegas distribution
+  vector<double> omega_initials, omega_frequencies_initials;
+  omega_initials.push_back(0.5); omega_initials.push_back(1); omega_initials.push_back(2);
+  omega_frequencies_initials.push_back(0.333333); omega_frequencies_initials.push_back(0.333333); omega_frequencies_initials.push_back(0.333334);
+
+  SimpleDiscreteDistribution* psdd = new SimpleDiscreteDistribution(omega_initials, omega_frequencies_initials);
+
+  map<string, DiscreteDistribution*> mpdd;
+  mpdd["omega"] = psdd;
+
+  // build the submodel as a basic Yang Nielsen model (with kappa instead of 5 GTR nucleotide substituion rate parameters) 
+  YN98* yn98 = new YN98(gc, codonFreqs);
+
+  // initialize the site model with the initial omegas distribution
+  pmixmodel_.reset(new MixtureOfASubstitutionModel(gc->getSourceAlphabet(), yn98, mpdd));
+  delete psdd; // delete the initial omegas distibution, that is already embedded in the mixture model
+
+  // mapping the parameters
+  ParameterList pl = pmixmodel_->getParameters();
+  for (size_t i = 0; i < pl.size(); i++)
+  {
+    string parName = pl[i].getName(); // debug
+    lParPmodel_.addParameter(Parameter(pl[i])); // add the parameter to the biblio wrapper instance - see Laurent's response in https://groups.google.com/forum/#!searchin/biopp-help-forum/likelihood$20ratio$20test|sort:date/biopp-help-forum/lH8MYit_Mr8/2CBND79B11YJ
+  }
+
+  // v consists of 9 shared theta parameters, that are used for the F3X4 estimation of codon frequencies  
+  vector<std::string> v = dynamic_cast<YN98*>(pmixmodel_->getNModel(0))->getFrequenciesSet()->getParameters().getParameterNames();
+
+  for (size_t i = 0; i < v.size(); i++)
+  {
+    mapParNamesFromPmodel_[v[i]] = v[i].substr(5);
+  }
+
+  // map the parameters of RELAX to the parameters of the sub-models
+  mapParNamesFromPmodel_["YN98.kappa"] = "kappa";
+  mapParNamesFromPmodel_["YN98.omega_Simple.V1"] = "p";           // omega0=p*omega1 (p is re-parameterization of omega0)
+  mapParNamesFromPmodel_["YN98.omega_Simple.V2"] = "omega1";     
+  mapParNamesFromPmodel_["YN98.omega_Simple.theta1"] = "theta1";  // frequency of omega1 (denoted in YNGP_M2's documentation as p0)
+  mapParNamesFromPmodel_["YN98.omega_Simple.V3"] = "omega2";
+  mapParNamesFromPmodel_["YN98.omega_Simple.theta2"] = "theta2";  // theta2 = (p1/(p1+p2))
+  /* codon frequencies parameterization using F3X4: for each theta, corresponding to a a codon position over {0,1,2}:
+  getFreq_(0) = theta1 * (1. - theta);
+  getFreq_(1) = (1 - theta2) * theta;
+  getFreq_(2) = theta2 * theta;
+  getFreq_(3) = (1 - theta1) * (1. - theta); */
+
+  string st;
+  for (map<string, string>::iterator it = mapParNamesFromPmodel_.begin(); it != mapParNamesFromPmodel_.end(); it++)
+  {
+    st = pmixmodel_->getParameterNameWithoutNamespace(it->first);
+    if (it->second.substr(0, 5) != "omega" && it->second.substr(0, 5) !="p")
+    {
+      addParameter_(new Parameter("RELAX." + it->second, pmixmodel_->getParameterValue(st),
+                              pmixmodel_->getParameter(st).hasConstraint() ? pmixmodel_->getParameter(st).getConstraint()->clone() : 0, true));
+    }
+  } 
+
+  /* set the below parameters that are used for parameterizing the omega parameters of the sumodels of type YN98 as autoparameters to supress exceptions when constraints of the YN98 omega parameters are exceeded
+  YN98_0.omega = (RELAX.p * RELAX.omega1) ^ RELAX.k
+  YN98_1.omega = RELAX.omega1 ^ RELAX.k  
+  YN98_2.omega = RELAX.omega2 ^ RELAX.k */
+  // reparameterization of omega0: RELAX.omega0 = RELAX.p*RELAX.omega1
+  addParameter_(new AutoParameter("RELAX.p", 0.5, new IntervalConstraint(0.5, 1, true, true), true));
+
+  addParameter_(new AutoParameter("RELAX.omega1", 1, new IntervalConstraint(0.075, 1, true, true), true));
+
+  // the upper bound of omega3 in its submodel is 999, so I must restrict upperBound(RELAX.omega2)^upperBound(RELAX.k)<=999 -> set maximal omega to 5  
+  addParameter_(new AutoParameter("RELAX.omega2", 2, new IntervalConstraint(1, 15, true, true), true));
+
+  // k: what about the theta parameters?
+
+  // add a selection intensity parameter k, which is 1 in the null case
+  Parameter* k = new Parameter("RELAX.k", 1, new IntervalConstraint(0.1, 2, true, true), true);
+  addParameter_(k);  // add the parameter to relax model  
+
+  // look for synonymous codons
+  // assumes that the states number follow the map in the genetic code and thus:
+  // synfrom_ = index of source codon
+  // synto_ = index of destination codon
+  vector<int> supportedChars = yn98->getAlphabetStates(); // includes stop codons
+
+  for (synfrom_ = 1; synfrom_ < supportedChars.size(); ++synfrom_)
+  {
+    for (synto_ = 0; synto_ < synfrom_; ++synto_)
+    {
+      if (gc->areSynonymous(supportedChars[synfrom_], supportedChars[synto_])
+          && (pmixmodel_->getNModel(0)->Qij(synfrom_, synto_) != 0)
+          && (pmixmodel_->getNModel(1)->Qij(synfrom_, synto_) != 0))
+        break;
+    }
+    if (synto_ < synfrom_)
+      break;
+  }
+
+  if (synto_ == supportedChars.size())
+    throw Exception("Impossible to find synonymous codons");
+
+  // update the 3 rate matrices of the model (strict BG or strict FG)
+  computeFrequencies(false);
+  updateMatrices();
+}
+
+
+void RELAX::updateMatrices()
+{
+  // update the values of the sub-model parameters, that are used in the 3 rate matrices
+  for (unsigned int i = 0; i < lParPmodel_.size(); i++)
+  {
+    // first update the values of the non omega patrameters
+    const string& np = lParPmodel_[i].getName();
+    if (mapParNamesFromPmodel_.find(np) != mapParNamesFromPmodel_.end())
+    { 
+      if (np.size()>19 && np[18] == 'V')
+      {
+        double k = getParameterValue("k"); // get the value of k
+        int ind = -1 ;
+        if (np.size()>19) {
+          ind = TextTools::to<int>(np.substr(19)) - 1; // ind corresponds to the index of the omega that belongs to submodel ind+1
+        }
+        // change ind not to be -1 to allow names omega1, omega2, omega3
+        if (ind > 0) {                    // raise each omega to the power of k
+          double omega =  getParameterValue("omega" + TextTools::toString(ind));
+          omega = pow (omega, k);
+          lParPmodel_[i].setValue(omega);
+        } else if (ind == 0) {                          // handle omega0 differently due to reparameterization via RELAX.p
+          double omega1 = getParameterValue("omega1");
+          double p = getParameterValue("p");
+          double omega0 = p * omega1;
+          omega0 = pow(omega0,k);
+          lParPmodel_[i].setValue(omega0); // update the omega of the first sub-model according to the transformation: omega0^k = (p*omega1)^k
+        }
+      }
+      else
+      {
+        lParPmodel_[i].setValue(getParameter(getParameterNameWithoutNamespace(mapParNamesFromPmodel_[np])).getValue());
+      }
+    }
+  }
+
+  pmixmodel_->matchParametersValues(lParPmodel_);
+
+  // normalize the synonymous substitution rate in all the Q matrices of the 3 submodels to be the same
+  Vdouble vd;
+
+  for (unsigned int i = 0; i < pmixmodel_->getNumberOfModels(); i++)
+  {
+    vd.push_back(1 / pmixmodel_->getNModel(i)->Qij(synfrom_, synto_));
+  }
+
+  pmixmodel_->setVRates(vd);
+}

--- a/src/Bpp/Phyl/Model/Codon/RELAX.h
+++ b/src/Bpp/Phyl/Model/Codon/RELAX.h
@@ -1,0 +1,108 @@
+//
+// File: RELAX.h
+// Created by: Keren Halabi
+// Created on: May 2018
+//
+
+/*
+  Copyright or © or Copr. CNRS, (November 16, 2004)
+
+  This software is a computer program whose purpose is to provide classes
+  for phylogenetic data analysis.
+
+  This software is governed by the CeCILL  license under French law and
+  abiding by the rules of distribution of free software.  You can  use, 
+  modify and/ or redistribute the software under the terms of the CeCILL
+  license as circulated by CEA, CNRS and INRIA at the following URL
+  "http://www.cecill.info". 
+
+  As a counterpart to the access to the source code and  rights to copy,
+  modify and redistribute granted by the license, users are provided only
+  with a limited warranty  and the software's author,  the holder of the
+  economic rights,  and the successive licensors  have only  limited
+  liability. 
+
+  In this respect, the user's attention is drawn to the risks associated
+  with loading,  using,  modifying and/or developing or reproducing the
+  software by the user in light of its specific status of free software,
+  that may mean  that it is complicated to manipulate,  and  that  also
+  therefore means  that it is reserved for developers  and  experienced
+  professionals having in-depth computer knowledge. Users are therefore
+  encouraged to load and test the software's suitability as regards their
+  requirements in conditions enabling the security of their systems and/or 
+  data to be ensured and,  more generally, to use and operate it in the 
+  same conditions as regards security. 
+
+  The fact that you are presently reading this means that you have had
+  knowledge of the CeCILL license and that you accept its terms.
+*/
+
+#ifndef _RELAX_H_
+#define _RELAX_H_
+
+
+#include <Bpp/Phyl/Model/Codon/YNGP_M.h>
+#include <Bpp/Seq/GeneticCode/GeneticCode.h>
+
+namespace bpp
+{
+
+/**
+ * @brief The RELAX (2014) branch-site model for codons
+ * The model detects changes in selective pressure based on a prior partition of the tree branches provided by the user
+ * @author Keren Halabi
+ *
+ * This model cocnsists of a mixture of models, each defined as described in YN98 class (will use kappa instead of 5 GTR parameters),
+ * The mixture is defined in two levels: the site level and the branch level
+ * The model consists of two site models - each one for a different branches group: brackground and foreground
+ * The site model of the background group is a mixture of 3 MG94 models 
+ * The YN98 (i.e, kappa) parameters, except for the omega value, are shared between the 3 sub-models
+ * Each site can be assigned to one of 3 omega classes that correspond to the 3 selective regimes:
+ * \omega_0 = omega_1 * p < 1 @f$ (with probability @f$p_0 @f$)
+ * \omega_1 <= 1 @f$ (with probability @f$p_1 @f$)
+ * \omega_2 > 1 @f$ (with probability 1-@f$p_1-@f$p_0 @f$)
+ * The omegas of the foreground group are obtained by raising the omegas of the background group to the power of a selection intensity parameter k
+ * Overall, the model consists of 9 parameters, base frequencies parameters excluded:
+ * 5 parameters for the GTR model that is nested in the MG94 model (Currently, the model is implemented with a single kappa parameter rather than 5 GTR parameters)
+ * 3 omega values parameters + 2 omega frequencies parameters
+ * 1 selection intensity parameter k
+ * 
+ * References:
+ *
+ * Joel O., et al. "RELAX: detecting relaxed selection in a phylogenetic framework." 
+ * Molecular biology and evolution 32.3 (2014): 820-832.‏
+ */
+  class RELAX:
+    public YNGP_M
+  {
+  public:
+    // gc is a pointer to a constant GeneticCode instance
+    // unlike GeneticCode const* gc - gc is a constant pointer to a GeneticCode instance
+    // see: https://stackoverflow.com/questions/3984989/what-is-the-differnce-between-const-x-a-and-x-const-a-if-x-is-the-class?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
+    RELAX(const GeneticCode* gc, FrequenciesSet* codonFreqs);
+
+    RELAX* clone() const { return new RELAX(*this); }
+
+    RELAX(const RELAX& mod2) :
+      YNGP_M(mod2)
+    {
+    }
+
+    RELAX& operator=(const RELAX& mod2)
+    {
+      YNGP_M::operator=(mod2);
+      return *this;
+    }
+
+  protected:
+    void updateMatrices();
+
+  public:
+    std::string getName() const { return "RELAX"; }
+
+  };
+
+} //end of namespace bpp.
+
+#endif	// _RELAX_H
+

--- a/src/Bpp/Phyl/Model/SubstitutionModelSet.cpp
+++ b/src/Bpp/Phyl/Model/SubstitutionModelSet.cpp
@@ -7,22 +7,18 @@
 
 /*
   Copyright or <A9> or Copr. CNRS, (November 16, 2004)
-
   This software is a computer program whose purpose is to provide classes
   for phylogenetic data analysis.
-
   This software is governed by the CeCILL  license under French law and
   abiding by the rules of distribution of free software.  You can  use,
   modify and/ or redistribute the software under the terms of the CeCILL
   license as circulated by CEA, CNRS and INRIA at the following URL
   "http://www.cecill.info".
-
   As a counterpart to the access to the source code and  rights to copy,
   modify and redistribute granted by the license, users are provided only
   with a limited warranty  and the software's author,  the holder of the
   economic rights,  and the successive licensors  have only  limited
   liability.
-
   In this respect, the user's attention is drawn to the risks associated
   with loading,  using,  modifying and/or developing or reproducing the
   software by the user in light of its specific status of free software,
@@ -33,7 +29,6 @@
   requirements in conditions enabling the security of their systems and/or
   data to be ensured and,  more generally, to use and operate it in the
   same conditions as regards security.
-
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 */
@@ -166,6 +161,23 @@ void SubstitutionModelSet::addModel(TransitionModel* model, const std::vector<in
       p->setName(pname + "_" + TextTools::toString(thisModelIndex+1));
       addParameter_(p);
     }
+}
+
+void SubstitutionModelSet::resetModelToNodels()
+{
+  // reset nodeToModel_
+  nodeToModel_.clear();
+  // reset modelToNodes_
+  modelToNodes_.clear();
+}
+
+void SubstitutionModelSet::setNodeToModel(size_t modelIndex, int nodeId)
+{
+  if (modelIndex > modelSet_.size()-1)
+    throw Exception("SubstitutionModelSet::setNodesToModel. There is no Substitution Model of index " + TextTools::toString(modelIndex));
+  
+  nodeToModel_[nodeId] = modelIndex;
+  modelToNodes_[modelIndex].push_back(nodeId);
 }
 
 void SubstitutionModelSet::replaceModel(size_t modelIndex, TransitionModel* model)
@@ -306,4 +318,3 @@ bool SubstitutionModelSet::hasMixedSubstitutionModel() const
     }
   return false;
 }
-

--- a/src/Bpp/Phyl/Model/SubstitutionModelSet.h
+++ b/src/Bpp/Phyl/Model/SubstitutionModelSet.h
@@ -390,6 +390,9 @@ public:
    */
   void addModel(TransitionModel* model, const std::vector<int>& nodesId);//, const std::vector<std::string>& newParams);
 
+  void setNodeToModel(size_t modelIndex, int nodeId); // Keren: added on my own to allow alternation of nodes assignemnts to existing nodes
+
+  void resetModelToNodels();  // Keren: added on my own to allow alternation of nodes assignemnts to existing nodes
   /**
    * @brief Replace a model in the set, and all corresponding
    * parameters. The replaced model deleted.

--- a/src/Bpp/Phyl/Model/SubstitutionModelSetTools.h
+++ b/src/Bpp/Phyl/Model/SubstitutionModelSetTools.h
@@ -73,6 +73,7 @@ class SubstitutionModelSetTools
         const Tree* tree
       );
 
+ 
     /**
      * @brief Create a SubstitutionModelSet object, with one model per branch.
      *
@@ -92,6 +93,20 @@ class SubstitutionModelSetTools
         const Tree* tree,
         const std::map<std::string, std::string>& aliasFreqNames,
         const std::vector<std::string>& globalParameterNames
+      );
+      
+
+    static SubstitutionModelSet* createNonHomogeneousModelSet2(
+        TransitionModel* model,
+        FrequenciesSet* rootFreqs,
+        const Tree* tree,
+        const std::map<std::string, std::string>& aliasFreqNames,
+        const std::vector<std::string>& globalParameterNames,
+        const std::vector<int>& subset1BranchIds,                        // keren 16.10.18 - added argument 
+        const std::vector<int>& subset2BranchIds,                        // keren 16.10.18 - added argument 
+        const std::vector<std::string>& subsetSharedParameterNames,           // keren 16.10.18 - added argument 
+        const std::vector<double>& subset1SharedParametersInitialValues, // keren 16.10.18 - added argument 
+        const std::vector<double>& subset2SharedParametersInitialValues  // keren 16.10.18 - added argument 
       );
 
 };

--- a/src/Bpp/Phyl/Model/TwoParameterBinarySubstitutionModel.cpp
+++ b/src/Bpp/Phyl/Model/TwoParameterBinarySubstitutionModel.cpp
@@ -1,0 +1,90 @@
+//
+// File: TwoParameterBinarySubstitutionModel.cpp
+// Created by: Keren Halabi
+// Created on: 2018
+//
+
+/*
+   Copyright or � or Copr. Bio++ Development Team, (November 16, 2004)
+
+   This software is a computer program whose purpose is to provide classes
+   for phylogenetic data analysis.
+
+   This software is governed by the CeCILL  license under French law and
+   abiding by the rules of distribution of free software.  You can  use,
+   modify and/ or redistribute the software under the terms of the CeCILL
+   license as circulated by CEA, CNRS and INRIA at the following URL
+   "http://www.cecill.info".
+
+   As a counterpart to the access to the source code and  rights to copy,
+   modify and redistribute granted by the license, users are provided only
+   with a limited warranty  and the software's author,  the holder of the
+   economic rights,  and the successive licensors  have only  limited
+   liability.
+
+   In this respect, the user's attention is drawn to the risks associated
+   with loading,  using,  modifying and/or developing or reproducing the
+   software by the user in light of its specific status of free software,
+   that may mean  that it is complicated to manipulate,  and  that  also
+   therefore means  that it is reserved for developers  and  experienced
+   professionals having in-depth computer knowledge. Users are therefore
+   encouraged to load and test the software's suitability as regards their
+   requirements in conditions enabling the security of their systems and/or
+   data to be ensured and,  more generally, to use and operate it in the
+   same conditions as regards security.
+
+   The fact that you are presently reading this means that you have had
+   knowledge of the CeCILL license and that you accept its terms.
+ */
+
+#include "TwoParameterBinarySubstitutionModel.h"
+
+// From the STL:
+#include <cmath>
+
+using namespace bpp;
+
+#include <Bpp/Numeric/Matrix/MatrixTools.h>
+
+using namespace std;
+
+/******************************************************************************/
+
+TwoParameterBinarySubstitutionModel::TwoParameterBinarySubstitutionModel(const BinaryAlphabet* alpha, double mu, double pi0) :
+  AbstractParameterAliasable("TwoParameterBinary."),
+  AbstractReversibleSubstitutionModel(alpha, new CanonicalStateMap(alpha, false), "Binary."),
+  mu_(mu),
+  pi0_(pi0)
+{
+  addParameter_(new Parameter(getNamespace() + "mu", mu_, &Parameter::R_PLUS_STAR));
+  addParameter_(new Parameter(getNamespace() + "pi0", pi0_, &FrequenciesSet::FREQUENCE_CONSTRAINT_SMALL));
+  updateMatrices();
+}
+
+/******************************************************************************/
+
+void TwoParameterBinarySubstitutionModel::updateMatrices()
+{
+  mu_ = getParameterValue("mu");
+  pi0_ = getParameterValue("pi0");
+
+  // Frequences:
+  freq_[0] = pi0_;
+  freq_[1] = 1 - pi0_;
+
+  // Exchangeability matrix:
+  exchangeability_(0,0) = -1 * mu_ * (1-pi0_) / pi0_;
+  exchangeability_(0,1) = 1;
+  exchangeability_(1,0) = 1;
+  exchangeability_(1,1) = -1 * mu_ * pi0_ / (1-pi0_);
+
+  AbstractReversibleSubstitutionModel::updateMatrices();
+}
+
+/******************************************************************************/
+
+void TwoParameterBinarySubstitutionModel::setMuBounds(double lb, double ub)
+{
+  IntervalConstraint* bounds = new IntervalConstraint(lb, ub, true, true); 
+  getParameter_("mu").setConstraint(bounds, true);
+}

--- a/src/Bpp/Phyl/Model/TwoParameterBinarySubstitutionModel.h
+++ b/src/Bpp/Phyl/Model/TwoParameterBinarySubstitutionModel.h
@@ -1,0 +1,86 @@
+//
+// File: BinarySubstitutionModel.h
+// Created by: Keren Halabi
+// Created on: 2018
+//
+
+/*
+   Copyright or � or Copr. Bio++ Development Team, (November 16, 2004)
+
+   This software is a computer program whose purpose is to provide classes
+   for phylogenetic data analysis.
+
+   This software is governed by the CeCILL  license under French law and
+   abiding by the rules of distribution of free software.  You can  use,
+   modify and/ or redistribute the software under the terms of the CeCILL
+   license as circulated by CEA, CNRS and INRIA at the following URL
+   "http://www.cecill.info".
+
+   As a counterpart to the access to the source code and  rights to copy,
+   modify and redistribute granted by the license, users are provided only
+   with a limited warranty  and the software's author,  the holder of the
+   economic rights,  and the successive licensors  have only  limited
+   liability.
+
+   In this respect, the user's attention is drawn to the risks associated
+   with loading,  using,  modifying and/or developing or reproducing the
+   software by the user in light of its specific status of free software,
+   that may mean  that it is complicated to manipulate,  and  that  also
+   therefore means  that it is reserved for developers  and  experienced
+   professionals having in-depth computer knowledge. Users are therefore
+   encouraged to load and test the software's suitability as regards their
+   requirements in conditions enabling the security of their systems and/or
+   data to be ensured and,  more generally, to use and operate it in the
+   same conditions as regards security.
+
+   The fact that you are presently reading this means that you have had
+   knowledge of the CeCILL license and that you accept its terms.
+ */
+
+#ifndef _TWOPARAMETERBINARYSUBSTITUTIONMODEL_H_
+#define _TWOPARAMETERBINARYSUBSTITUTIONMODEL_H_
+
+#include "AbstractSubstitutionModel.h"
+#include <Bpp/Seq/Alphabet/BinaryAlphabet.h>
+
+namespace bpp
+{
+/**
+ * @brief The Model on two states
+ *
+ * \f[
+ * Q = mu.\begin{pmatrix}
+ * -\pi_{0} & \pi_{0}  \\
+ * \pi_{1} & -\pi_{1}  \\
+ * \end{pmatrix}
+ * \f]
+ */
+
+class TwoParameterBinarySubstitutionModel :
+  public AbstractReversibleSubstitutionModel
+{
+private:
+  double mu_;
+  double pi0_;
+
+public:
+  TwoParameterBinarySubstitutionModel(const BinaryAlphabet* alpha, double mu = 1., double pi0 = 0.5);
+
+  virtual ~TwoParameterBinarySubstitutionModel() {}
+
+  TwoParameterBinarySubstitutionModel* clone() const { return new TwoParameterBinarySubstitutionModel(*this); }
+
+  std::string getName() const { return "TwoParameterBinary"; }
+
+  size_t getNumberOfStates() const { return 2; }
+
+  void setMuBounds(double lb, double ub);
+
+protected:
+  void updateMatrices();
+
+};
+} // end of namespace bpp.
+
+#endif  // _BINARYSUBSTITUTIONMODEL_H_
+

--- a/src/Bpp/Phyl/Parsimony/DRTreeParsimonyScore.h
+++ b/src/Bpp/Phyl/Parsimony/DRTreeParsimonyScore.h
@@ -1,4 +1,4 @@
-//
+// keren: I assume that here bitset stands for weather there is an intersection (0) or union (1)
 // File: DRTreeParsimonyScore.h
 // Created by: Julien Dutheil
 // Created on: Thu Jul 28 18:31 2005
@@ -103,6 +103,25 @@ protected:
 public:
   unsigned int getScore() const;
   unsigned int getScoreForSite(size_t site) const;
+
+  // functions for computing a mximum parsimony solution, in the form of states assignments to internal nodes
+  
+  /** sets the state of a node in a mapping 
+    * @param node               The node to get the state of
+    * @param state              The state that needs to be assigned to the node
+    */
+  void setNodeState(Node* node, size_t state);
+
+  /** extracts the state of a node in a mapping 
+    * @param node              The node to get the state of
+    * @return                  Node state is int
+  */
+  int getNodeState(const Node* node);
+  
+  /**
+   * @brief Compute a maximum parsimony solution in DELTRAN manner.
+   */  
+  void computeSolution();
 
   /**
    * @brief Compute bitsets and scores for each site for a node, in postorder.

--- a/src/Bpp/Phyl/Simulation/MutationProcess.cpp
+++ b/src/Bpp/Phyl/Simulation/MutationProcess.cpp
@@ -127,7 +127,7 @@ SimpleMutationProcess::SimpleMutationProcess(const SubstitutionModel* model) :
   // Each element contains the probabilities concerning each character in the alphabet.
 
   // We will now initiate each of these probability vector.
-  RowMatrix<double> Q = model->getGenerator();
+  RowMatrix<double> Q = model->getGenerator(); // under RELAX matrix of zeros - don't know why
   for (size_t i = 0; i < size_; i++)
   {
     repartition_[i] = Vdouble(size_,0);

--- a/src/Bpp/Phyl/Simulation/MutationProcess.h
+++ b/src/Bpp/Phyl/Simulation/MutationProcess.h
@@ -113,6 +113,10 @@ class MutationPath
      * @return A pointer toward the alphabet associated to this path.
      */
     const Alphabet* getAlphabet() const { return alphabet_; }
+
+    const std::vector<size_t> getStates() const { return states_; }
+
+    const std::vector<double> getTimes() const { return times_; }
     
     /**
      * @brief Add a new mutation event.

--- a/src/Bpp/Phyl/TreeIterator.cpp
+++ b/src/Bpp/Phyl/TreeIterator.cpp
@@ -1,0 +1,218 @@
+#include "TreeIterator.h"
+
+// imports from bpp-core
+#include <Bpp/BppBoolean.h>
+
+#include <iostream>
+#include <fstream>
+
+using namespace bpp;
+
+using namespace std;
+
+#define LAST_VISITED_SON "last_visited_son"
+# define IS_VISITED "is_visited"
+
+/******************************************************************************/
+
+void TreeIterator::init()
+{
+    vector <Node*> nodes = tree_.getNodes();
+    for (size_t i=0; i<nodes.size(); ++i) 
+    {
+        setLastVisitedSon(nodes[i],-1);
+        nodes[i]->setNodeProperty(IS_VISITED, BppBoolean(false));
+    }
+}
+
+
+Node* TreeIterator::begin()
+{
+    curNode_->setNodeProperty(IS_VISITED, BppBoolean(true));
+    if (curNode_->hasFather())
+    {
+        setLastVisitedSon(curNode_->getFather(), getLastVisitedSon(curNode_->getFather())+1);
+    }
+    return curNode_;
+}
+
+
+void TreeIterator::clearProperties()
+{
+    vector <Node*> nodes = tree_.getNodes();
+    for (size_t i=0; i<nodes.size(); ++i) 
+    {
+        nodes[i]->removeNodeProperty(LAST_VISITED_SON);
+        nodes[i]->removeNodeProperty(IS_VISITED);
+    }
+}
+
+
+TreeIterator& TreeIterator::operator++()    // prefix ++
+{
+    this->next();
+    return *this;
+}
+
+
+int TreeIterator::getLastVisitedSon(Node* node) 
+{
+    BppInteger* posProperty = dynamic_cast<BppInteger*>(node->getNodeProperty(LAST_VISITED_SON));
+    int posValue = posProperty->getValue();
+    return posValue;
+}
+
+
+void TreeIterator::setLastVisitedSon(Node* node, int visitedSon)
+{
+    node->setNodeProperty(LAST_VISITED_SON, BppInteger(visitedSon));
+}
+
+
+Node* PostOrderTreeIterator::getLeftMostPredessesor(Node* startNode)
+{
+    int nextPos = getLastVisitedSon(startNode)+1;
+    // if startNode has no predessesors ->  move to him
+    if (nextPos >= static_cast<int>(startNode->getNumberOfSons()))
+    {
+        return startNode;
+    }
+	Node* next = startNode->getSon(nextPos);
+	Node* node = next;
+	while (node->getNumberOfSons() > 0) 
+    {
+		node = node->getSon(0);
+	}
+	return node;
+}
+
+
+Node* PostOrderTreeIterator::next() 
+{   // order: (left, right, parent)
+    // stop condition: curNode_ is root
+    if (!curNode_->hasFather())
+    {
+        clearProperties();
+        return NULL;
+    }
+    // by the time you visit curNode_, all the nodes in its subtree were already visited
+    int numOfBrothers =  static_cast<int>(curNode_->getFather()->getNumberOfSons()); // get the number of brothers of curNode_
+    int lastVisitedBrotherPos = getLastVisitedSon(curNode_->getFather());
+    // if all the brothers were already visited -> now visit the father
+    if (lastVisitedBrotherPos == numOfBrothers-1)
+    {
+        curNode_ = curNode_->getFather();
+    }
+    // else -> visit the leaftmost presdessesor next brother on the list
+    else 
+    {
+        int nextSiblingPos = getLastVisitedSon(curNode_->getFather())+1;
+        curNode_ = curNode_->getFather()->getSon(nextSiblingPos);
+        curNode_ = getLeftMostPredessesor(curNode_);
+    }                                        
+    // update the returned node to be visited and its father's last visited son, if needed
+    if (curNode_->hasFather())
+    {
+        setLastVisitedSon(curNode_->getFather(), getLastVisitedSon(curNode_->getFather())+1);
+    }
+    curNode_->setNodeProperty(IS_VISITED,BppBoolean(true));
+    return curNode_;
+}
+
+
+Node* PreOrderTreeIterator::next() 
+{   // order: (parent, left, right)
+    // stop condition: the node is the righmost leaf of the tree 
+    vector<int> leafIds = tree_.getLeavesId();
+    if (curNode_->getId() == leafIds[leafIds.size()-1])
+    {
+        clearProperties();
+        return NULL;
+    }
+    // by the time you visit curNode_, all its ancestors and left brothers (if exist) were already visited
+    int numOfSons =  static_cast<int>(curNode_->getNumberOfSons());
+    int lastVisitedSonPos = getLastVisitedSon(curNode_);
+    // as long as there are still sons to visit -> visit the lesftmost unvisited son
+    if (lastVisitedSonPos < numOfSons-1)
+    {
+        curNode_ = curNode_->getSon(lastVisitedSonPos+1);       
+    // else -> traverse to the leftmost brother which is right to curNode_
+    } 
+    else 
+    {
+       curNode_ = curNode_->getFather();
+       lastVisitedSonPos = getLastVisitedSon(curNode_);
+       numOfSons = static_cast<int>(curNode_->getNumberOfSons());
+       while (lastVisitedSonPos == numOfSons-1)
+       {
+            curNode_ = curNode_->getFather();
+            lastVisitedSonPos = getLastVisitedSon(curNode_);
+            numOfSons = static_cast<int>(curNode_->getNumberOfSons());
+       }
+        curNode_ = curNode_->getSon(lastVisitedSonPos+1);    
+    }
+    // update the returned node to be visited and its father's last visited son, if needed
+    if (curNode_->hasFather())
+    {
+        setLastVisitedSon(curNode_->getFather(), getLastVisitedSon(curNode_->getFather())+1);
+    }
+    curNode_->setNodeProperty(IS_VISITED,BppBoolean(true));
+    return curNode_;
+}
+
+
+Node* InOrderTreeIterator::doStep(Node* node)
+{
+    // if the node has unvisited left sons -> visit the leftmost unvisited son
+    int lastVisitedSon = getLastVisitedSon(node);
+    int numOfSons = static_cast<int>(node->getNumberOfSons());
+    int nextSon;
+    bool is_visited =  dynamic_cast<BppBoolean*>(node->getNodeProperty(IS_VISITED))->getValue();
+    // if the node has unvisited left sons - go to the leftmost unvisited son
+    if (lastVisitedSon < floor(numOfSons/2)-1)
+    {
+        nextSon = lastVisitedSon+1;
+        return node->getSon(nextSon);
+    }
+    // if the node last visited its last left son or is a leaf / parent of a single node -> go to it
+    else if (node->getNumberOfSons() > 1 && lastVisitedSon == floor(numOfSons/2)-1 && !is_visited)
+    {
+        return node;
+    }
+    // if the node has unvisited right sons -> go to the leftmost unviited right son
+    else if (lastVisitedSon < numOfSons-1)
+    {
+        nextSon = lastVisitedSon+1;
+        return node->getSon(nextSon);
+    }
+    // else - the entire subtree of the node has been scanned - move to its father
+    else 
+    {
+        return node->getFather();
+    }
+}
+
+
+Node* InOrderTreeIterator::next()
+{   // order: (left (0,..,n/2-1), parent, right (n/2,....,n))
+    // stop condition: the node is the righmost leaf of the tree 
+    vector<int> leafIds = tree_.getLeavesId();
+    if (curNode_->getId() == leafIds[leafIds.size()-1])
+    {
+        clearProperties();
+        return NULL;
+    }
+    bool is_visited = dynamic_cast<BppBoolean*>(curNode_->getNodeProperty(IS_VISITED))->getValue();
+    while (is_visited || (getLastVisitedSon(curNode_) < floor(curNode_->getNumberOfSons()/2)-1 && !curNode_->isLeaf()))  // while curNode still has unvisited left sons -> do another step
+    {
+        curNode_ = doStep(curNode_);
+        is_visited = dynamic_cast<BppBoolean*>(curNode_->getNodeProperty(IS_VISITED))->getValue();
+    }
+    // update the returned node to be visited and its father's last visited son, if needed
+    if (curNode_->hasFather())
+    {
+        setLastVisitedSon(curNode_->getFather(), getLastVisitedSon(curNode_->getFather())+1);
+    }
+    curNode_->setNodeProperty(IS_VISITED,BppBoolean(true));
+    return curNode_;
+}

--- a/src/Bpp/Phyl/TreeIterator.h
+++ b/src/Bpp/Phyl/TreeIterator.h
@@ -1,0 +1,160 @@
+//
+// File: TreeIterator.h
+// Created by: Keren Halabi
+// Created on: Thu Jul 5 14:03:18 2018
+//
+
+/*
+   Copyright or © or Copr. Bio++ Development Team, (November 16, 2004)
+
+   This software is a computer program whose purpose is to provide classes
+   for phylogenetic data analysis.
+
+   This software is governed by the CeCILL  license under French law and
+   abiding by the rules of distribution of free software.  You can  use,
+   modify and/ or redistribute the software under the terms of the CeCILL
+   license as circulated by CEA, CNRS and INRIA at the following URL
+   "http://www.cecill.info".
+
+   As a counterpart to the access to the source code and  rights to copy,
+   modify and redistribute granted by the license, users are provided only
+   with a limited warranty  and the software's author,  the holder of the
+   economic rights,  and the successive licensors  have only  limited
+   liability.
+
+   In this respect, the user's attention is drawn to the risks associated
+   with loading,  using,  modifying and/or developing or reproducing the
+   software by the user in light of its specific status of free software,
+   that may mean  that it is complicated to manipulate,  and  that  also
+   therefore means  that it is reserved for developers  and  experienced
+   professionals having in-depth computer knowledge. Users are therefore
+   encouraged to load and test the software's suitability as regards their
+   requirements in conditions enabling the security of their systems and/or
+   data to be ensured and,  more generally, to use and operate it in the
+   same conditions as regards security.
+
+   The fact that you are presently reading this means that you have had
+   knowledge of the CeCILL license and that you accept its terms.
+ */
+
+#ifndef _TREEITERATORS_H
+#define _TREEITERATORS_H
+
+#include "TreeTemplate.h"
+#include "Node.h"
+
+// From the STL:
+#include <string>
+#include <vector>
+#include <map>
+
+/**
+ * @brief The phylogenetic tree iterator class.
+ *
+ * This class is part of the object implementation of phylogenetic trees. 
+ *
+ * The class offers iterators for traversing the nodes in a tree in 3 possible orders:
+ * Post-Order
+ * Pre-Order
+ * In-Order
+ *
+ * For more information on using trees in BIo++, 
+ * @see Node
+ * @see NodeTemplate
+ * @see TreeTools
+ */
+
+namespace bpp
+{
+
+    class TreeIterator                  // abstract class from which each iterator type inherits
+    {
+        protected:
+        TreeTemplate<Node>& tree_;      // The tree to iterate over its nodes. Can't be const because user should be allowed to edit the nodes of the tree during the traversal.
+        Node* curNode_;                 // A pointer to the current node visited by the iterator. Can't be const because user should be allowed to edit the nodes of the tree during the traversal.
+
+        public:
+        /* contructors and destructors */
+        explicit TreeIterator(TreeTemplate<Node>& tree):
+            tree_(tree),
+            curNode_(tree.getRootNode()) // The pointer to the initial node is initialized as 0 since it's actual assignment depents on which traversal is chosen
+            { init(); }
+
+        explicit TreeIterator(TreeIterator& tree_iterator):
+        tree_(tree_iterator.tree_),
+        curNode_(tree_.getRootNode())
+        {}
+
+        TreeIterator& operator=(const TreeIterator& tree_iterator);
+        
+        virtual ~TreeIterator() {}      // No need to delete anything - the pointer to the node should not be deleted because the node doesn't belong to the tree iterator
+                                        // must be virtual to assume that upon deletion, the destructor of any inheriting class is called as well (see https://www.geeksforgeeks.org/virtual-destructor/)
+
+        void init();                    // function to initialize nodes properties
+        /* iterating functions */
+        Node* begin();     
+        virtual Node* next() = 0;                   // Set as virtual because the function should be implemented separately in each iterator type
+        TreeIterator& operator++();
+        Node* end(){ return NULL; }
+
+        protected:
+        void clearProperties();
+        int getLastVisitedSon(Node* node);
+        void setLastVisitedSon(Node* node, int visitedSon);
+    };
+
+
+    class PostOrderTreeIterator: public TreeIterator
+    {
+        public:
+
+        /* constrcutors and destrcutors */
+        explicit PostOrderTreeIterator(TreeTemplate<Node>& tree):
+        TreeIterator(tree) {
+            curNode_ = tree_.getNodes()[0]; // Get the leftmost leaf of the tree
+        }
+
+        ~PostOrderTreeIterator() {};           // Inherited from TreeIterator
+
+        Node* getLeftMostPredessesor(Node* startNode);
+        Node* next();
+    };
+
+
+    class PreOrderTreeIterator: public TreeIterator
+    {
+        public:
+
+        /* constrcutors and destrcutors */
+        explicit PreOrderTreeIterator(TreeTemplate<Node>& tree):
+        TreeIterator(tree) {
+            curNode_ = tree_.getRootNode();
+        }
+
+        ~PreOrderTreeIterator() {};           // Inherited from TreeIterator
+
+        Node* next();
+    };
+
+
+    class InOrderTreeIterator: public TreeIterator
+    {
+        public:
+
+        /* constrcutors and destrcutors */
+        explicit InOrderTreeIterator(TreeTemplate<Node>& tree):
+        TreeIterator(tree) {
+            curNode_ = tree_.getNodes()[0];  // Get the leftmost leaf of the tree
+        }
+
+        ~InOrderTreeIterator() {};           // Inherited from TreeIterator
+
+        Node* doStep(Node* node);
+        Node* next();
+
+    }; 
+
+
+} // end of namespace bpp.
+
+#endif // _TREEITERATORS_H 

--- a/test/test_stochastic_mapping.cpp
+++ b/test/test_stochastic_mapping.cpp
@@ -1,0 +1,421 @@
+// Tester for StochasticMapping implementation
+
+// From the STL:
+#include <vector>
+#include <string>
+#include <iostream>
+#include <fstream>
+
+// From bpp-core:
+#include <Bpp/Text/TextTools.h>
+#include <Bpp/App/ApplicationTools.h>
+#include <Bpp/Numeric/AutoParameter.h>
+#include <Bpp/Numeric/Prob/DiscreteDistribution.h>
+#include <Bpp/Numeric/Prob/ConstantDistribution.h>
+#include <Bpp/Seq/Alphabet/AlphabetTools.h>
+
+// From bpp-seq:
+#include <Bpp/Seq/SiteTools.h> 
+#include <Bpp/Seq/Alphabet/Alphabet.h>
+#include <Bpp/Seq/App/SequenceApplicationTools.h>
+#include <Bpp/Seq/Container/SiteContainerTools.h>
+#include <Bpp/Seq/SequenceTools.h>
+
+// From bpp-phyl
+#include <Bpp/Phyl/TreeTemplate.h>
+#include <Bpp/Phyl/Model/SubstitutionModelSetTools.h>
+#include <Bpp/Phyl/Model/TwoParameterBinarySubstitutionModel.h>
+#include <Bpp/Phyl/Likelihood/RHomogeneousTreeLikelihood.h>
+#include <Bpp/Phyl/Model/RateDistribution/ConstantRateDistribution.h>
+#include <Bpp/Phyl/Mapping/StochasticMapping.h>
+#include <Bpp/Phyl/OptimizationTools.h>
+#include <Bpp/Phyl/App/PhylogeneticsApplicationTools.h>
+#include <Bpp/Phyl/Simulation/DetailedSiteSimulator.h>
+#include <Bpp/Phyl/Simulation/NonHomogeneousSequenceSimulator.h>
+#include <Bpp/Phyl/Simulation/SequenceSimulationTools.h>
+
+using namespace bpp;
+using namespace std;
+
+#define STATE "state"
+#define WRITE_PATH "/media/sf_sf_Biopp/data/mappings/"
+
+
+/******************************************************************************/
+
+void checkIfMappingLegal(const StochasticMapping* stocMapping, const Tree* mapping, const TreeTemplate<Node>* baseTree, const TreeLikelihood* tl)
+{
+    // make sure that the states are the leafs are set properly
+    vector<const Node*> origNodes = baseTree->getNodes();
+    vector<const Node*> mappingNodes = dynamic_cast<const TreeTemplate<Node>*>(mapping)->getNodes();
+    const SiteContainer* leafsStates = tl->getData();
+    for (size_t i=0; i<origNodes.size(); ++i)
+    {
+        if (origNodes[i]->isLeaf())
+        {
+            string nodeName = origNodes[i]->getName();
+            int origNodeState = static_cast<int>(tl->getAlphabetStateAsInt(leafsStates->getSequence(nodeName).getValue(0)));
+            const Node* nodeInMapping = (dynamic_cast<const TreeTemplate<Node>*>(mapping))->getNode(nodeName);
+            int nodeStateInMapping = stocMapping->getNodeState(nodeInMapping);
+            if (origNodeState != nodeStateInMapping)
+            {
+                 throw Exception("Leafs states not maintained in mapping");
+            }
+        }
+    }
+            
+    // make sure that branch lengths are maintained in the mapping
+    for (size_t i=0; i<origNodes.size(); ++i)
+    {
+        if (origNodes[i]->hasFather())
+        {
+            double origBranchLength = origNodes[i]->getDistanceToFather();
+            const Node* nodeInMapping = (dynamic_cast<const TreeTemplate<Node>*>(mapping))->getNode(origNodes[i]->getName());
+            const Node* origNodeFatherInMapping = (dynamic_cast<const TreeTemplate<Node>*>(mapping))->getNode(origNodes[i]->getFather()->getName());
+            double branchLengthInMapping = 0;
+            const Node* curNode = nodeInMapping;
+            while (curNode != origNodeFatherInMapping)
+            {
+                if (curNode->hasFather())
+                {
+                    branchLengthInMapping += curNode->getDistanceToFather(); // failes on node with id 9, but returns exception on node with id 6 (which is the root)
+                    curNode = curNode->getFather();
+                }
+                else
+                {
+                    branchLengthInMapping = origBranchLength;
+                    curNode = origNodeFatherInMapping;
+                }
+            }
+            if (branchLengthInMapping > origBranchLength + 0.01 || branchLengthInMapping < origBranchLength - 0.01) // expected history fails in the root - but the branch length of the branch coming from the root is insignificant as it isn't included in the tree. what happened here?
+            {
+                throw Exception("branch lengths not maintained in mapping");
+            }
+        }
+    }
+
+    // make sure there are no two nodes in a raw such that both don't exist in the base tree and both recieve the same state (indicator of illegal transition)
+    for (size_t i=0; i<origNodes.size(); ++i)
+    {
+        if (origNodes[i]->hasFather())
+        {
+            const Node* nodeInMapping = (dynamic_cast<const TreeTemplate<Node>*>(mapping))->getNode(origNodes[i]->getName());
+            string origFatherName = origNodes[i]->getFather()->getName();
+            const Node* origNodeFatherInMapping = (dynamic_cast<const TreeTemplate<Node>*>(mapping))->getNode(origFatherName);
+            const Node* curNode = nodeInMapping;
+            while (curNode->getFather() != origNodeFatherInMapping)
+            {
+                string curNodeFatherName = curNode->getFather()->getName();
+                string origNodeFatherInMappingName = origNodeFatherInMapping->getName();
+                int curNodeState = stocMapping->getNodeState(curNode);
+                int nextNodeState = stocMapping->getNodeState(curNode->getFather());
+                if (curNodeState == nextNodeState && origNodes[i]->getFather()->hasFather()) // such transition is permitted in case the father is the root
+                {
+                    throw Exception("illegal transitions in the mapping");
+                }
+                curNode = curNode->getFather();
+            }
+        }
+    }
+}
+
+
+void printMapping(const StochasticMapping* stocMapping, const Tree* mapping) 
+{
+    ApplicationTools::displayMessage("\n\nPrinting mapping\n");
+    string label = "state";
+    vector<const Node*> nodes = (dynamic_cast<const TreeTemplate<Node>*>(mapping))->getNodes(); 
+    for (int i=0; i < static_cast<int>(nodes.size()); i++) {
+        if (nodes[i]->hasFather()) 
+        {
+        string name = nodes[i]->getName();
+        double bl = nodes[i]->getDistanceToFather();
+        int state = stocMapping->getNodeState(nodes[i]);
+        ApplicationTools::displayMessage("Node (name: " + TextTools::toString(name) + ", branch_length: " + TextTools::toString(bl) + ", state: " + TextTools::toString(state) + ")");
+        }
+    }
+}
+
+
+void printModelParameters(const DiscreteRatesAcrossSitesTreeLikelihood* tl)
+{
+    ParameterList parameters = tl->getSubstitutionModelParameters();
+    for (size_t i = 0; i < parameters.size(); i++)
+    {
+    ApplicationTools::displayResult(parameters[i].getName(), TextTools::toString(parameters[i].getValue()));
+    }
+    parameters = tl->getRateDistributionParameters();
+    for (size_t i = 0; i < parameters.size(); i++)
+    {
+      ApplicationTools::displayResult(parameters[i].getName(), TextTools::toString(parameters[i].getValue()));
+    }
+    ParameterList pl = tl->getBranchLengthsParameters();
+    for(unsigned int i = 0; i < pl.size(); i++)
+    {
+      ApplicationTools::displayResult(pl[i].getName(), TextTools::toString(pl[i].getValue())); 
+    }
+}
+
+
+void giveNamesToInternalNodes(Tree* tree)
+{
+    TreeTemplate<Node>* ttree = dynamic_cast<TreeTemplate<Node>*>(tree);
+    vector<Node*> nodes = ttree->getNodes();
+    for (size_t i=0; i<nodes.size(); ++i) {
+        if (!nodes[i]->hasName())
+            nodes[i]->setName("_baseInternal_" + TextTools::toString(nodes[i]->getId()));
+    }  
+}
+
+
+int getNodeState(const Node* node)
+{
+    return (dynamic_cast<const BppInteger*>(node->getNodeProperty(STATE)))->getValue(); // exception on root on the true history - why didn't the root recieve a state?
+}
+
+
+void setNodeState(Node* node, size_t state)
+{
+    node->setNodeProperty(STATE,BppInteger(static_cast<int>(state)));
+}
+
+
+void updateStatesInNodesNames(Tree* mapping)
+{
+    string label = "state";
+    vector<Node*> nodes = (dynamic_cast<TreeTemplate<Node>*>(mapping))->getNodes(); 
+    for (int i=0; i < static_cast<int>(nodes.size()); i++) 
+    {
+        string name = nodes[i]->getName();
+        int state = getNodeState(nodes[i]);
+        nodes[i]->setName(name + "{" + TextTools::toString(state) + "}");
+    }
+}
+
+
+// since the function is fitted to true history, the mutation path may exceed the original branch length, in which case the dutration until the last event should be reduced to fit the original branch length
+void updateBranchMapping(Node* son, const MutationPath& branchMapping, size_t initial_count)
+{ 
+    static size_t nodesCounter_ = initial_count;
+    const vector<size_t> states = branchMapping.getStates();
+    const VDouble times = branchMapping.getTimes();
+    Node* curNode = son;
+    double origBranchLength = son->getDistanceToFather();
+    Node* nextNode;
+    int eventsNum = static_cast<int>(branchMapping.getNumberOfEvents());
+    if (eventsNum == 0)  // if there are no events -> return nothing
+    {
+        return;
+    }
+    else
+    {
+        // update the branch length of the node to be as per the time of the last event
+        double duration = 0;
+        for (int i=eventsNum-2; i>-1; --i) 
+        { // add a new node to represent the transition
+            nodesCounter_ += 1;
+            const string name = "_mappingInternal" + TextTools::toString(nodesCounter_) + "_";
+            nextNode = new Node(static_cast<int>(nodesCounter_), name); // nodes counter isn't incremented properly
+            setNodeState(nextNode,states[i]);
+            if (i == 0)
+            {
+                duration = times[i];    
+            }
+            else
+            {
+                duration = times[i]-times[i-1]; // the duration is the gap between the two adjacent times
+            }
+            nextNode->setDistanceToFather(duration);    // according to the simulator, the documented time is the accumulated time until the transition and NOT the time since the last transition
+            
+            // set the father to no longer be the father of curNode
+            if (curNode->hasFather()) // as long as we haven't reached the root -> upate the father of the current node
+            {
+                Node* originalFather = curNode->getFather();
+                originalFather->removeSon(curNode); // also removes originalFather as the father of curNode
+                // set nextNode to be the new father of curNode
+                curNode->setFather(nextNode); // also adds curNode to the sons of nextNode
+                // set curNode's original father ot be the father of nextNode
+                nextNode->setFather(originalFather); // also adds nextNode to the sons of originalFather - or not? make sure this is the father at all times
+                curNode = nextNode;
+            }
+        }
+        // if the sum of distances doesn't add up to the length of the original branch, add an event or change the duration of the last event, depending on the last assigned state
+        double lastEventDuration = origBranchLength - times[eventsNum-2]; 
+        if (lastEventDuration > 0)
+        {
+            son->setDistanceToFather(lastEventDuration);
+        }
+    }
+    return;
+}
+
+
+
+// translate the simulation data into a tree format, similar to the one given by the stochastic mappings
+// in the results, there is a mutations paths field that can be returned for each node getMutationPath(int nodeId)
+// then, it is enough to use the function I built in StochasticMapping
+Tree* extractTrueHistory(RASiteSimulationResult* simulationData, Tree* baseTree)
+{
+    Tree* history = baseTree->clone();
+    giveNamesToInternalNodes(history);
+    vector<Node*> nodes = (dynamic_cast<TreeTemplate<Node>*>(history))->getNodes();
+    vector<Node*> debugNodes;
+    // set the ancestral states for all the nodes
+    for (size_t j=0; j<nodes.size(); ++j)
+    {
+        size_t state = simulationData->getAncestralState(nodes[j]->getId());
+        setNodeState(nodes[j], state);
+    }
+    for (size_t i=0; i<nodes.size(); ++i)
+    {
+        string name = nodes[i]->getName();
+        if (nodes[i]->hasFather())
+        {
+            const MutationPath branchHistory = simulationData->getMutationPath(nodes[i]->getId());
+            updateBranchMapping(nodes[i], branchHistory, nodes.size()-1);
+        } 
+    }
+    // now, add the label of each internal node in the updated history to the node's name
+    updateStatesInNodesNames(history);
+    debugNodes = (dynamic_cast<TreeTemplate<Node>*>(history))->getNodes(); // for debugging
+    return history;
+}
+
+
+void evaluateApproxmation(RHomogeneousTreeLikelihood* tl, const size_t NUM_OF_MAPPINGS,  TreeTemplate<Node>* tree)
+{
+        std::map<std::string, std::string> writeParams;
+        string file_path;
+        writeParams["output.tree.format"] = "Newick";
+        cout << "**** generating stochasting mappings ****" << endl;
+        StochasticMapping* stocMapping = new StochasticMapping(dynamic_cast<TreeLikelihood*>(tl), NUM_OF_MAPPINGS);
+        vector<Tree*> mappings;
+        stocMapping->generateStochasticMapping(mappings);
+
+        // make sure the mapping is legal. and if it is, print it
+        for (size_t i=0; i<NUM_OF_MAPPINGS; ++i)
+        {
+            checkIfMappingLegal(stocMapping, mappings[i], tree, tl);
+            //printMapping(stocMapping, mappings[i]);
+        }
+        cout << "" << endl;
+        
+        // average the stochastic mappings
+        cout << "**** generating expected mapping from the sampled stochasting mappings by method ((Pf/Pf+Ps),(Ps/Pf+Ps)) on division of dwelling time of state shared by son and father ****" << endl;
+        Tree* expectedMapping_1 = stocMapping->generateExpectedMapping(mappings, 0); // bug in the expected history -branch lengths are not maintained
+        checkIfMappingLegal(stocMapping, expectedMapping_1, tree, tl);
+        printMapping(stocMapping, expectedMapping_1);
+        cout << "" << endl;
+
+        cout << "**** generating expected mapping from the sampled stochasting mappings by method (0%,100%) on division of dwelling time of state shared by son and father ****" << endl;
+        Tree* expectedMapping_2 = stocMapping->generateExpectedMapping(mappings, 1); // bug in the expected history -branch lengths are not maintained
+        checkIfMappingLegal(stocMapping, expectedMapping_2, tree, tl);
+        //printMapping(stocMapping, expectedMapping_2);
+        cout << "" << endl;
+ 
+ 
+        // write and then delete all the mappings
+        for (size_t i=0; i<NUM_OF_MAPPINGS; ++i)
+        {
+            updateStatesInNodesNames(mappings[i]);
+            file_path = WRITE_PATH + TextTools::toString(NUM_OF_MAPPINGS) + string("_histories/sm/history_") + TextTools::toString(i) + string(".nwk");
+            writeParams["output.tree.file"] = file_path;
+            PhylogeneticsApplicationTools::writeTree(*mappings[i], writeParams);
+            delete mappings[i];
+        }
+        mappings.clear();
+        // write and then delete the expected mapping
+        updateStatesInNodesNames(expectedMapping_1);
+        file_path =  WRITE_PATH + TextTools::toString(NUM_OF_MAPPINGS) + string("_histories/expected_history_div_Ps_Pf.nwk");
+        writeParams["output.tree.file"] = file_path;
+        PhylogeneticsApplicationTools::writeTree(*expectedMapping_1, writeParams); // node properties are not written - need to create a function that adds the properties to the nodes names (hopefully internal nodes names are written as well)
+        delete expectedMapping_1;
+
+        updateStatesInNodesNames(expectedMapping_2);
+        file_path =  WRITE_PATH + TextTools::toString(NUM_OF_MAPPINGS) + string("_histories/expected_history_div_0_100.nwk");
+        writeParams["output.tree.file"] = file_path;
+        PhylogeneticsApplicationTools::writeTree(*expectedMapping_2, writeParams); // node properties are not written - need to create a function that adds the properties to the nodes names (hopefully internal nodes names are written as well)
+        delete expectedMapping_2;
+        delete stocMapping;
+}
+
+
+int main() 
+{
+    try
+    {
+        // process the base tree
+        //TreeTemplate<Node>* tree = TreeTemplateTools::parenthesisToTree("(((((taxon_76:0.496929,((taxon_107:0.318441,(taxon_97:0.0159542,taxon_112:0.0159542):0.302486):0.0913119,(taxon_115:0.0372323,taxon_64:0.0372323):0.37252):0.0871764):0.512717,((taxon_100:0.348635,taxon_16:0.348635):0.586186,taxon_30:0.934821):0.074825):0.922849,((((taxon_84:0.165705,taxon_90:0.165705):0.878595,((taxon_63:0.831182,taxon_34:0.831182):0.0861682,taxon_49:0.91735):0.12695):0.0704198,((taxon_54:0.308919,taxon_103:0.308919):0.00428333,taxon_35:0.313203):0.801518):0.535358,(((((((taxon_62:0.0114359,taxon_113:0.0114359):0.183922,taxon_5:0.195357):0.277249,taxon_27:0.472607):0.149748,((taxon_89:0.379836,(taxon_105:0.116668,taxon_79:0.116668):0.263168):0.186337,taxon_96:0.566173):0.056181):0.26954,(taxon_21:0.653842,taxon_68:0.653842):0.238051):0.440175,taxon_47:1.33207):0.108835,(((((taxon_102:0.310821,(((((taxon_117:0.078882,taxon_109:0.078882):0.0435369,taxon_24:0.122419):0.0257292,taxon_40:0.148148):0.1129,(taxon_93:0.114194,(taxon_31:0.0114579,taxon_110:0.0114579):0.102736):0.146854):0.00819116,taxon_120:0.269239):0.0415812):0.159443,((taxon_116:0.333268,(taxon_8:0.274037,(taxon_38:0.10085,(taxon_127:0.0628677,(taxon_2:0.0302643,taxon_86:0.0302643):0.0326033):0.0379826):0.173187):0.0592309):0.0527145,(taxon_19:0.164283,taxon_125:0.164283):0.221699):0.0842811):0.538943,((((taxon_83:0.125342,taxon_60:0.125342):0.198194,(taxon_122:0.248157,(taxon_33:0.0833234,taxon_57:0.0833234):0.164834):0.0753784):0.0645332,taxon_106:0.388069):0.604844,((taxon_41:0.436068,taxon_69:0.436068):0.524348,taxon_51:0.960416):0.0324962):0.0162942):0.144357,taxon_92:1.15356):0.0883542,((taxon_108:0.0902716,taxon_11:0.0902716):0.330309,taxon_87:0.420581):0.821337):0.198986):0.209175):0.282416):0.0675047,((((((((taxon_99:0.0682924,taxon_50:0.0682924):0.643115,(((taxon_104:0.287754,taxon_65:0.287754):0.362259,((taxon_14:0.384113,(taxon_91:0.32686,taxon_101:0.32686):0.0572534):0.00244688,(taxon_25:0.11595,taxon_81:0.11595):0.27061):0.263453):0.0290233,((taxon_124:0.334751,(taxon_121:0.126325,taxon_85:0.126325):0.208425):0.187795,(taxon_48:0.120423,(taxon_123:0.037176,taxon_58:0.037176):0.0832468):0.402123):0.156491):0.032371):0.122432,(taxon_3:0.190266,taxon_67:0.190266):0.643573):0.343819,(taxon_45:0.0614213,taxon_28:0.0614213):1.11624):0.0281366,((taxon_32:0.344014,(taxon_7:0.258017,taxon_74:0.258017):0.0859975):0.501839,(taxon_111:0.66751,(((taxon_94:0.0880479,taxon_15:0.0880479):0.515293,((taxon_73:0.121536,(taxon_52:0.00849519,taxon_70:0.00849519):0.113041):0.00709992,taxon_23:0.128636):0.474705):0.0516189,(taxon_80:0.650887,(taxon_59:0.519428,(taxon_78:0.461878,(taxon_88:0.0870246,taxon_61:0.0870246):0.374853):0.0575505):0.131458):0.00407329):0.0125497):0.178344):0.359941):0.0329343,(((taxon_46:0.0215311,taxon_6:0.0215311):0.103302,taxon_20:0.124833):0.719305,(taxon_13:0.422967,(taxon_37:0.293719,taxon_66:0.293719):0.129248):0.421171):0.39459):0.0578141,((((taxon_82:0.451795,((((taxon_56:0.106496,((taxon_72:1.08453e-05,taxon_126:1.08453e-05):0.00491296,taxon_55:0.0049238):0.101572):0.0144704,taxon_75:0.120966):0.0983091,(taxon_26:0.0578083,(taxon_1:0.0332433,taxon_119:0.0332433):0.0245649):0.161467):0.0318726,((taxon_9:0.123689,taxon_39:0.123689):0.076446,taxon_95:0.200135):0.0510127):0.200647):0.172515,(taxon_18:0.315929,(taxon_53:0.226351,taxon_42:0.226351):0.0895782):0.308381):0.0930432,taxon_17:0.717353):0.499559,(((taxon_22:0.0629585,taxon_98:0.0629585):0.0807454,taxon_71:0.143704):0.869988,(taxon_43:0.312529,taxon_77:0.312529):0.701163):0.20322):0.0796314):0.649234,(((taxon_128:0.104818,taxon_10:0.104818):0.509612,(taxon_12:0.110661,taxon_36:0.110661):0.503769):0.858453,((((taxon_4:0.141369,taxon_118:0.141369):0.267746,taxon_44:0.409116):0.195081,taxon_29:0.604197):0.0821644,taxon_114:0.686361):0.786522):0.472894):0.0542229):0.407829);");
+        TreeTemplate<Node>* tree = TreeTemplateTools::parenthesisToTree("((S1:1,S2:1):1,(S3:1,S4:1):1):1;");
+        Tree& ttree = dynamic_cast<Tree&>(*tree);
+        giveNamesToInternalNodes(&ttree);
+        // write the base tree to the main analysis path 
+        std::map<std::string, std::string> writeParams;
+        string file_path = WRITE_PATH + string("base_tree.nwk");
+        writeParams["output.tree.file"] = file_path;
+        writeParams["output.tree.format"] = "Newick";
+        PhylogeneticsApplicationTools::writeTree(ttree, writeParams);
+
+        vector<Node*> nodes = tree->getNodes();
+
+        // create a binary model
+        const BinaryAlphabet* alphabet = new BinaryAlphabet();
+        double mu = 2.;
+        double pi0 = 0.5;
+        SubstitutionModel* model = new TwoParameterBinarySubstitutionModel(alphabet,mu,pi0); // second arguent stands for mu
+        DiscreteDistribution* rdist = new ConstantRateDistribution();
+
+        // 15.8.18 - simulate character history using a simulator over a simple binary model
+        NonHomogeneousSequenceSimulator* simulator = new NonHomogeneousSequenceSimulator(model, rdist, &ttree);
+        //simulator->outputInternalSequences(true); // get the internal sequences in the sites container as well for later comparison
+        vector<string> seqNames = tree->getLeavesNames();
+        VectorSiteContainer sites(seqNames, alphabet);
+        
+        RASiteSimulationResult* result = simulator->dSimulateSite();
+        unique_ptr<Site> site(result->getSite(*simulator->getSubstitutionModelSet()->getModel(0)));
+        site->setPosition(0);
+        sites.addSite(*site, false);
+        Tree* trueHistory = extractTrueHistory(result, &ttree);
+        // write the true history to a file
+        file_path = WRITE_PATH + string("true_history.nwk");
+        writeParams["output.tree.file"] = file_path;
+        PhylogeneticsApplicationTools::writeTree(*trueHistory, writeParams);
+        delete trueHistory;
+        // write the character data into a file
+        file_path = WRITE_PATH + string("char_data.fas");
+        writeParams["output.sequence.file"] = file_path;
+        writeParams["output.sequence.format"] = "Fasta";
+        SequenceApplicationTools::writeSequenceFile(*(dynamic_cast<SequenceContainer*>(&sites)), writeParams, "", false, 1);
+
+        // create a likelihood function
+        RHomogeneousTreeLikelihood* tl = new RHomogeneousTreeLikelihood(ttree, dynamic_cast<const SiteContainer&>(sites), dynamic_cast<TransitionModel*>(model), rdist,false);
+        tl->initialize();
+        ApplicationTools::displayResult("Log likelihood", TextTools::toString(-tl->getValue(), 15));
+        printModelParameters(tl);
+        
+        // evaluate the sotchastic mappinfs based approxmations
+        cout<< "***** approximation based on 100 stochastic mappings *****" << endl;
+        evaluateApproxmation(tl, 100, tree);
+
+        cout<< "***** approximation based on 1000 stochastic mappings *****" << endl;
+        evaluateApproxmation(tl, 1000, tree);
+
+        cout<< "***** approximation based on 10000 stochastic mappings *****" << endl;
+        evaluateApproxmation(tl, 10000, tree);
+
+        // delete all the created instances
+        delete tl;
+        delete rdist;
+        delete tree;
+        delete model;
+        delete alphabet;
+        delete result;
+        delete simulator;
+    }
+    catch (exception & e)
+    {
+        cout << e.what() << endl;
+        return 1;
+    }
+    return 0;
+}

--- a/test/test_tree_iterators.cpp
+++ b/test/test_tree_iterators.cpp
@@ -1,0 +1,223 @@
+// Test for TreeIterator implementation
+
+// From the STL:
+#include <vector>
+#include <string>
+#include <iostream>
+#include <fstream>
+
+using namespace std;
+
+// From bpp-core:
+#include <Bpp/Text/TextTools.h>
+#include <Bpp/App/ApplicationTools.h>
+#include <Bpp/Numeric/AutoParameter.h>
+
+
+// From bpp-phyl
+#include <Bpp/Phyl/App/PhylogeneticsApplicationTools.h>
+#include <Bpp/Phyl/TreeIterator.h>
+
+using namespace bpp;
+
+void testPostOderIterator()
+{
+        // binary tree
+        cout << "Test PostOrderIterator" << endl;
+        cout << "Test on simple binary tree" << endl;
+        TreeTemplate<Node>* binPostOrderTree = TreeTemplateTools::parenthesisToTree("((A:1,B:1):1,D:1);");
+        vector <Node*> nodes = binPostOrderTree->getNodes();
+        for (size_t i=0; i < nodes.size(); ++i)
+        {
+            Node* node = nodes[i];
+            if (!node->isLeaf() && !node->hasFather())      // node is root
+            {
+                node->setName("E"); 
+            }
+            else if (!node->isLeaf() && node->hasFather())  // node is internal but not the root
+            {
+                node->setName("C");
+            }
+        }
+        cout << "Visiting nodes of ((A,B)C,D)E; in post-order -> printed nodes names should match lexicographic order" << endl;
+        PostOrderTreeIterator* binPostOrderTreeIt = new PostOrderTreeIterator(*binPostOrderTree);
+        for (Node* node = binPostOrderTreeIt->begin(); node != binPostOrderTreeIt->end(); node = binPostOrderTreeIt->next())
+        {
+             cout << node->getName() << endl;
+        }
+        cout << "\n" << endl;
+        delete(binPostOrderTreeIt);
+        delete(binPostOrderTree);
+
+        // non binary tree
+        cout << "Test on non-binary tree" << endl;
+        TreeTemplate<Node>* nonBinPostOrderTree = TreeTemplateTools::parenthesisToTree("(((A:1):1,(C:1,D:1,E:1):1):1,H:1);");
+        nodes = nonBinPostOrderTree->getNodes();
+        for (size_t i=0; i < nodes.size(); ++i) // who is node 7?
+        {
+            Node* node = nodes[i];
+            if (!node->isLeaf() && !node->hasFather())      // node is root
+            {
+                node->setName("I"); 
+            }
+            else if (!node->isLeaf() && node->hasFather())  // node is internal but not the root
+            {
+                if (node->getSon(0)->getName() == "A") {
+                    node->setName("B");
+                } else if (node->getSon(0)->getName() == "C") {
+                    node->setName("F");
+                } else if (node->getSon(0)->getName() == "B") {
+                    node->setName("G"); // this is the 3rd node in nodes -which indicates it doesn't match the post order
+                }
+                
+            }
+        }
+
+        cout << "Visiting nodes of ((A)B,(C,D,E)F)G,H)I; in post-order -> printed nodes names should match lexicographic order" << endl;
+        PostOrderTreeIterator* nonBinPostOrderTreeIt = new PostOrderTreeIterator(*nonBinPostOrderTree);
+        for (Node* node = nonBinPostOrderTreeIt->begin(); node != nonBinPostOrderTreeIt->end(); node = nonBinPostOrderTreeIt->next())
+        {
+             cout << node->getName() << endl;
+        }
+        cout << "\n" << endl;
+        delete(nonBinPostOrderTreeIt);
+        delete(nonBinPostOrderTree);      
+}
+
+void testPreOrderIterator()
+{
+        // binary tree
+        cout << "Test PreOrderIterator" << endl;
+        cout << "Test on simple binary tree" << endl;
+        TreeTemplate<Node>* binPreOrderTree  = TreeTemplateTools::parenthesisToTree("((C:1,D:1):1,E:1);");
+        vector <Node*> nodes = binPreOrderTree->getNodes();
+        for (size_t i=0; i < nodes.size(); ++i)
+        {
+            Node* node = nodes[i];
+            if (!node->isLeaf() && !node->hasFather()) // node is root
+            {
+                node->setName("A"); 
+            }
+            else if (!node->isLeaf() && node->hasFather()) // node is internal but not the root
+            {
+                node->setName("B");
+            }
+        }
+        cout << "Visiting nodes of ((C,D)B,E)A; in pre-order -> printed nodes names should match lexicographic order" << endl;
+        PreOrderTreeIterator* binPreOrderTreeIt = new PreOrderTreeIterator(*binPreOrderTree);
+        for (Node* node = binPreOrderTreeIt->begin(); node != binPreOrderTreeIt->end(); node = binPreOrderTreeIt->next())
+        {
+             cout << node->getName() << endl;
+        }
+        cout << "\n" << endl;
+        delete(binPreOrderTreeIt);
+        delete(binPreOrderTree);
+
+        // non binary tree
+        cout << "Test on non-binary tree" << endl;
+        TreeTemplate<Node>* nonBinPreOrderTree  = TreeTemplateTools::parenthesisToTree("(((D:1):1,(F:1,G:1,H:1):1):1,I:1);");
+        nodes = nonBinPreOrderTree->getNodes();
+        for (size_t i=0; i < nodes.size(); ++i)
+        {
+            Node* node = nodes[i];
+            if (!node->isLeaf() && !node->hasFather()) {
+                node->setName("A"); 
+            } else if (!node->isLeaf() && node->getSon(0)->getName() == "D") {
+                node->setName("C");
+            } else if (!node->isLeaf() && node->getSon(0)->getName() == "F") {
+                node->setName("E");
+            } else if (!node->isLeaf() && node->getSon(0)->getName() == "C") {
+                node->setName("B");
+            } 
+        }
+
+        cout << "Visiting nodes of (((D)C,(F,G,H)E)B,I)A; in pre-order -> printed nodes names should match lexicographic order" << endl;
+        PreOrderTreeIterator* nonBinPreOrderTreeIt = new PreOrderTreeIterator(*nonBinPreOrderTree);
+        for (Node* node = nonBinPreOrderTreeIt->begin(); node != nonBinPreOrderTreeIt->end(); node = nonBinPreOrderTreeIt->next())
+        {
+             cout << node->getName() << endl;
+        }
+        cout << "\n" << endl;
+        delete(nonBinPreOrderTreeIt);
+        delete(nonBinPreOrderTree);
+}
+
+void testInOderIterator()
+{
+        // binary tree
+        cout << "Test InOrderIterator" << endl;
+        cout << "Test on simple binary tree" << endl;
+        TreeTemplate<Node>* binInOrderTree   = TreeTemplateTools::parenthesisToTree("((A:1,C:1):1,E:1);");
+        vector <Node*> nodes = binInOrderTree->getNodes();
+        for (size_t i=0; i < nodes.size(); ++i)
+        {
+            Node* node = nodes[i];
+            if (!node->isLeaf() && !node->hasFather()) // node is root
+            {
+                node->setName("D"); 
+            }
+            else if (!node->isLeaf() && node->hasFather()) // node is internal but not the root
+            {
+                node->setName("B");
+            }
+        }
+        cout << "Visiting nodes of ((A,C)B,E)D; in in-order -> printed nodes names should match lexicographic order" << endl;
+        InOrderTreeIterator* binInOrderTreeIt = new InOrderTreeIterator(*binInOrderTree);
+        for (Node* node = binInOrderTreeIt->begin(); node != binInOrderTreeIt->end(); node = binInOrderTreeIt->next())
+        {
+             cout << node->getName() << endl;
+        }
+        cout << "\n" << endl;
+        delete(binInOrderTreeIt);
+        delete(binInOrderTree);
+
+        // non binary tree
+        cout << "Test on non-binary tree" << endl;
+        TreeTemplate<Node>* nonBinInOrderTree   = TreeTemplateTools::parenthesisToTree("(((A:1):1,(D:1,F:1,G:1):1):1,(I:1,J:1,L:1,M:1):1);");
+        nodes = nonBinInOrderTree->getNodes();
+        for (size_t i=0; i < nodes.size(); ++i)
+        {
+            Node* node = nodes[i];
+            if (!node->isLeaf() && !node->hasFather()) {
+                node->setName("H"); 
+            } else if (!node->isLeaf() && node->getSon(0)->getName() == "A") {
+                node->setName("B");
+            } else if (!node->isLeaf() && node->getSon(0)->getName() == "D") {
+                node->setName("E");
+            } else if (!node->isLeaf() && node->getSon(0)->getName() == "B") {
+                node->setName("C");
+            } else if (!node->isLeaf() && node->getSon(0)->getName() == "I") {
+                node->setName("K");
+            } 
+        }
+        cout << "Visiting nodes of (((A)B,(D,F,G)E)C,(I,J,L,M)K)H; in in-order -> printed nodes names should match lexicographic order" << endl;
+        InOrderTreeIterator* nonBinInOrderTreeIt = new InOrderTreeIterator(*nonBinInOrderTree);
+        for (Node* node = nonBinInOrderTreeIt->begin(); node != nonBinInOrderTreeIt->end(); node = nonBinInOrderTreeIt->next())
+        {
+             cout << node->getName() << endl;
+        }
+        cout << "\n" << endl;
+        delete(nonBinInOrderTreeIt);
+        delete(nonBinInOrderTree);
+}
+
+int main() 
+{
+    try
+    {
+        // Bio++ doesn't handle internal node names when reading the tree, so first I need to set the internal nodes names in each case
+
+        testPostOderIterator();
+
+        testPreOrderIterator();
+
+        testInOderIterator();
+        
+    }
+    catch (exception & e)
+    {
+        cout << e.what() << endl;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Added auxiliary functions to allow change of model to node assignments in an existing model set, as discussed in [google group](https://groups.google.com/forum/#!category-topic/biopp-help-forum/all-questions/UknO2J__hBE).

Addition: 

Function resetModelToNodels() to reset existing model indices to node Ids assignments.
Function setNodeToModel() to set assignment of model index to node Id.

For convenience, added comments on the functions in the .h file. If approved, please feel free to alter the comments to the required syntax.