### PR TITLE
Added two functions to class SubstitutionModelSet

### DIFF
--- a/src/Bpp/Phyl/Model/SubstitutionModelSet.cpp
+++ b/src/Bpp/Phyl/Model/SubstitutionModelSet.cpp
@@ -7,22 +7,18 @@
 
 /*
   Copyright or <A9> or Copr. CNRS, (November 16, 2004)
-
   This software is a computer program whose purpose is to provide classes
   for phylogenetic data analysis.
-
   This software is governed by the CeCILL  license under French law and
   abiding by the rules of distribution of free software.  You can  use,
   modify and/ or redistribute the software under the terms of the CeCILL
   license as circulated by CEA, CNRS and INRIA at the following URL
   "http://www.cecill.info".
-
   As a counterpart to the access to the source code and  rights to copy,
   modify and redistribute granted by the license, users are provided only
   with a limited warranty  and the software's author,  the holder of the
   economic rights,  and the successive licensors  have only  limited
   liability.
-
   In this respect, the user's attention is drawn to the risks associated
   with loading,  using,  modifying and/or developing or reproducing the
   software by the user in light of its specific status of free software,
@@ -33,7 +29,6 @@
   requirements in conditions enabling the security of their systems and/or
   data to be ensured and,  more generally, to use and operate it in the
   same conditions as regards security.
-
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 */
@@ -166,6 +161,23 @@ void SubstitutionModelSet::addModel(TransitionModel* model, const std::vector<in
       p->setName(pname + "_" + TextTools::toString(thisModelIndex+1));
       addParameter_(p);
     }
+}
+
+void SubstitutionModelSet::resetModelToNodeIds()
+{
+  // reset nodeToModel_
+  nodeToModel_.clear();
+  // reset modelToNodes_
+  modelToNodes_.clear();
+}
+
+void SubstitutionModelSet::setNodeToModel(size_t modelIndex, int nodeId)
+{
+  if (modelIndex > modelSet_.size()-1)
+    throw Exception("SubstitutionModelSet::setNodesToModel. There is no Substitution Model of index " + TextTools::toString(modelIndex));
+  
+  nodeToModel_[nodeId] = modelIndex;
+  modelToNodes_[modelIndex].push_back(nodeId);
 }
 
 void SubstitutionModelSet::replaceModel(size_t modelIndex, TransitionModel* model)
@@ -306,4 +318,3 @@ bool SubstitutionModelSet::hasMixedSubstitutionModel() const
     }
   return false;
 }
-

--- a/src/Bpp/Phyl/Model/SubstitutionModelSet.h
+++ b/src/Bpp/Phyl/Model/SubstitutionModelSet.h
@@ -391,6 +391,21 @@ public:
   void addModel(TransitionModel* model, const std::vector<int>& nodesId);//, const std::vector<std::string>& newParams);
 
   /**
+   * @brief Sets an assignment of a given modle index to a given onde id
+   *
+   * @param modelIndex The index of the model in the set.
+   * @param model      The node ID
+   *
+   * @throw Exception if the modle index doesn't correspond to an existing modle in the modelSet
+   */
+  void setNodeToModel(size_t modelIndex, int nodeId); // Keren: added on my own to allow alternation of nodes assignemnts to existing nodes
+  
+  /**
+   * @brief Reset model indices to node ids assignment
+   */
+  void resetModelToNodeIds();  // Keren: added on my own to allow alternation of nodes assignemnts to existing nodes
+
+  /**
    * @brief Replace a model in the set, and all corresponding
    * parameters. The replaced model deleted.
    *
@@ -399,7 +414,6 @@ public:
    *
    * @throw Exception if a parameter becomes orphan because of the removal.
    */
-
   void replaceModel(size_t modelIndex, TransitionModel* model);
 
   void listModelNames(std::ostream& out = std::cout) const;


### PR DESCRIPTION
Hi Julien,

As per your explanation, I am pulling request a single commit that consists of addition of two functions to class SubstitutionModelSet in Bpp/Phyl/Model:

resetModelToNodeIds - resets the data members that dictate the mapping of model indices to node ids
setNodeToModel - updates the same data members with a mapping of a given model index to a given node id

Thanks!
Keren
