### PR TITLE
Added parallelization component to likelihood computation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,15 @@ IF(NO_DEP_CHECK)
   MESSAGE("-- Dependencies checking disabled. Only distribution can be built.")
 ELSE(NO_DEP_CHECK)
 
+# include openmp for parallelization of likelihood computation
+find_package(OpenMP)
+if (OPENMP_FOUND)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+    set (OMP_NUM_THREADS 4)
+endif()
+
 # Libtool-like version number
 # CURRENT:REVISION:AGE => file.so.(C-A).A.R
 # current:  The most recent interface number that this library implements.

--- a/src/Bpp/Phyl/Likelihood/RHomogeneousMixedTreeLikelihood.cpp
+++ b/src/Bpp/Phyl/Likelihood/RHomogeneousMixedTreeLikelihood.cpp
@@ -1,6 +1,7 @@
 //
-// File: RHomogeneousMixedTreeLikelihood.h
-// Created by: David Fournier, Laurent Gueguen
+// File: RNonHomogeneousMixedTreeLikelihood.cpp
+// Created by: Laurent Gueguen
+// Created on: jeudi 11 novembre 2010, à 07h 56
 //
 
 /*
@@ -36,304 +37,824 @@
    knowledge of the CeCILL license and that you accept its terms.
  */
 
-#include "RHomogeneousMixedTreeLikelihood.h"
+#include "RNonHomogeneousMixedTreeLikelihood.h"
+#include "../PatternTools.h"
+#include "../Model/MixedSubstitutionModel.h"
+#include "../TreeTools.h"
 
+#include <Bpp/Numeric/NumConstants.h>
+#include <Bpp/Text/TextTools.h>
+#include <Bpp/App/ApplicationTools.h>
+
+#include <omp.h>
+
+using namespace bpp;
 
 // From the STL:
 #include <iostream>
 
-#include <cmath>
-#include "../PatternTools.h"
-
-#include <Bpp/Numeric/VectorTools.h>
-#include <Bpp/App/ApplicationTools.h>
-
-using namespace bpp;
 using namespace std;
 
-RHomogeneousMixedTreeLikelihood::RHomogeneousMixedTreeLikelihood(
-  const Tree& tree,
-  TransitionModel* model,
-  DiscreteDistribution* rDist,
-  bool checkRooted,
-  bool verbose,
-  bool usePatterns) :
-  RHomogeneousTreeLikelihood(tree, model, rDist, checkRooted, verbose, usePatterns),
-  treeLikelihoodsContainer_(),
-  probas_()
+/******************************************************************************/
+
+RNonHomogeneousMixedTreeLikelihood::RNonHomogeneousMixedTreeLikelihood(const Tree& tree,
+                                                                       MixedSubstitutionModelSet* modelSet,
+                                                                       DiscreteDistribution* rDist,
+                                                                       bool verbose,
+                                                                       bool usePatterns) :
+  RNonHomogeneousTreeLikelihood(tree, modelSet, rDist, verbose, usePatterns),
+  mvTreeLikelihoods_(),
+  hyperNode_(modelSet),
+  upperNode_(tree.getRootId()),
+  main_(true)
 {
-  MixedSubstitutionModel* mixedmodel;
-  if ((mixedmodel = dynamic_cast<MixedSubstitutionModel*>(model_)) == 0)
-    throw Exception("Bad model: RHomogeneousMixedTreeLikelihood needs a MixedSubstitutionModel.");
-  size_t s = mixedmodel->getNumberOfModels();
-  for (size_t i = 0; i < s; i++)
-  {
-    treeLikelihoodsContainer_.push_back(
-      new RHomogeneousTreeLikelihood(tree, mixedmodel->getNModel(i), rDist, checkRooted, false, usePatterns));
-    probas_.push_back(mixedmodel->getNProbability(i));
+  if (!modelSet->isFullySetUpFor(tree))
+    throw Exception("RNonHomogeneousMixedTreeLikelihood(constructor). Model set is not fully specified.");
+
+  for (size_t i=0;i<modelSet->getNumberOfHyperNodes();i++){
+    mvTreeLikelihoods_[tree.getRootId()].push_back(new RNonHomogeneousMixedTreeLikelihood(tree, modelSet, modelSet->getHyperNode(i), upperNode_, rDist, false, usePatterns));
+  }
+
+}
+
+/******************************************************************************/
+
+RNonHomogeneousMixedTreeLikelihood::RNonHomogeneousMixedTreeLikelihood(const Tree& tree,
+                                                                       const SiteContainer& data,
+                                                                       MixedSubstitutionModelSet* modelSet,
+                                                                       DiscreteDistribution* rDist,
+                                                                       bool verbose,
+                                                                       bool usePatterns) :
+  RNonHomogeneousTreeLikelihood(tree, data, modelSet, rDist, verbose, usePatterns),
+  mvTreeLikelihoods_(),
+  hyperNode_(modelSet),
+  upperNode_(tree.getRootId()),
+  main_(true)
+{
+  if (!modelSet->isFullySetUpFor(tree))
+    throw Exception("RNonHomogeneousMixedTreeLikelihood(constructor). Model set is not fully specified.");
+
+  for (size_t i=0;i<modelSet->getNumberOfHyperNodes();i++)
+    mvTreeLikelihoods_[tree.getRootId()].push_back(new RNonHomogeneousMixedTreeLikelihood(tree, data, modelSet, modelSet->getHyperNode(i), upperNode_, rDist, false, usePatterns));
+}
+
+/******************************************************************************/
+
+RNonHomogeneousMixedTreeLikelihood::RNonHomogeneousMixedTreeLikelihood(const Tree& tree,
+                                                                       MixedSubstitutionModelSet* modelSet,
+                                                                       const MixedSubstitutionModelSet::HyperNode& hyperNode,
+                                                                       int upperNode,
+                                                                       DiscreteDistribution* rDist,
+                                                                       bool verbose,
+                                                                       bool usePatterns) :
+  RNonHomogeneousTreeLikelihood(tree, modelSet, rDist, verbose, usePatterns),
+  mvTreeLikelihoods_(),
+  hyperNode_(hyperNode),
+  upperNode_(upperNode),
+  main_(false)
+{
+  if (!modelSet->isFullySetUpFor(tree))
+    throw Exception("RNonHomogeneousMixedTreeLikelihood(constructor). Model set is not fully specified.");
+
+  init(usePatterns);
+}
+
+/******************************************************************************/
+
+RNonHomogeneousMixedTreeLikelihood::RNonHomogeneousMixedTreeLikelihood(const Tree& tree,
+                                                                       const SiteContainer& data,
+                                                                       MixedSubstitutionModelSet* modelSet,
+                                                                       const MixedSubstitutionModelSet::HyperNode& hyperNode,
+                                                                       int upperNode,
+                                                                       DiscreteDistribution* rDist,
+                                                                       bool verbose,
+                                                                       bool usePatterns) :
+  RNonHomogeneousTreeLikelihood(tree, data, modelSet, rDist, verbose, usePatterns),
+  mvTreeLikelihoods_(),
+  hyperNode_(hyperNode),
+  upperNode_(upperNode),
+  main_(false)
+{
+  if (!modelSet->isFullySetUpFor(tree))
+    throw Exception("RNonHomogeneousMixedTreeLikelihood(constructor). Model set is not fully specified.");
+
+  init(usePatterns);
+}
+
+/******************************************************************************/
+
+void RNonHomogeneousMixedTreeLikelihood::init(bool usePatterns)
+{
+  std::vector<int> vDesc; // vector of the explorated descendents
+  int desc;
+  vector<int> vn;
+  size_t nbmodels = modelSet_->getNumberOfModels();
+
+  const SiteContainer* pdata = getData();
+  
+  const Tree& tree = getTree();
+  
+  vDesc.push_back(upperNode_); // start of the exploration
+
+  while (vDesc.size() != 0)  {
+    desc = vDesc.back();
+    vDesc.pop_back();
+    vector<int> vExpMod; // vector of the ids of the MixedModels which
+                         // nodes are not in only one subtree under desc
+
+    vector<int> vson = tree.getSonsId(desc);
+    std::map<int, vector<int> > mdesc; // map of the subtree nodes for
+                                       // each son of desc
+    for (size_t i = 0; i < vson.size(); i++)
+    {
+      std::vector<int> vi;
+      TreeTools::getNodesId(tree, vson[i], vi);
+      mdesc[vson[i]] = vi;
+    }
+
+    for (size_t i = 0; i < nbmodels; i++)
+    {
+      const MixedSubstitutionModelSet::HyperNode::Node& node = hyperNode_.getNode(i);
+      
+      if (node.size()>1)
+      {
+        vn = modelSet_->getNodesWithModel(i); // tree nodes associated to model
+
+        /* Check if the vn members are in the same subtree */
+        size_t flag = 0; // count of the subtrees that have vn members
+        std::map<int, vector<int> >::iterator it;
+        for (it = mdesc.begin(); it != mdesc.end(); it++)
+        {
+          for (size_t j = 0; j < it->second.size(); j++)
+            {
+            if (it->second[j] != it->first)
+            {
+              if (find(vn.begin(), vn.end(), it->second[j]) != vn.end())
+              {
+                flag += (find(vn.begin(), vn.end(), it->first) != vn.end()) ? 2 : 1; // check if the son
+                // has this model too
+                break;
+              }
+            }
+            else if (find(vn.begin(), vn.end(), it->first) != vn.end())
+              flag++;
+          }
+          if (flag >= 2)
+            break;
+        }
+        if (flag >= 2)
+          vExpMod.push_back(static_cast<int>(i));  // mixed model that must be expanded
+      }
+    }
+
+    if (vExpMod.size() != 0)
+    {
+      std::map<int, int> mapmodels;
+      size_t ttmodels = 1;
+      for (vector<int>::iterator it = vExpMod.begin(); it != vExpMod.end(); it++)
+      {
+        mapmodels[*it] = static_cast<int>(hyperNode_.getNode(static_cast<size_t>(*it)).size());
+        ttmodels *= static_cast<size_t>(mapmodels[*it]);
+      }
+
+      for (size_t i = 0; i < ttmodels; i++)
+      {
+        int s = static_cast<int>(i);
+        MixedSubstitutionModelSet::HyperNode hn(hyperNode_);
+        
+        for (size_t j = 0; j < nbmodels; j++)
+        {
+          if ((hyperNode_.getNode(j).size() >= 1) && find(vExpMod.begin(), vExpMod.end(), static_cast<int>(j)) != vExpMod.end())
+          {
+            hn.setModel(j, Vint(1, hyperNode_.getNode(j)[static_cast<size_t>(s % mapmodels[static_cast<int>(j)])]));
+            s /= mapmodels[static_cast<int>(j)];
+          }
+        }
+        hn.setProbability((dynamic_cast<MixedSubstitutionModelSet*>(modelSet_))->getHyperNodeProbability(hn));
+        RNonHomogeneousMixedTreeLikelihood* pr;
+
+        if (pdata)
+          pr = new RNonHomogeneousMixedTreeLikelihood(tree, *pdata, dynamic_cast<MixedSubstitutionModelSet*>(modelSet_), hn, desc, rateDistribution_, false, usePatterns);
+        else
+          pr = new RNonHomogeneousMixedTreeLikelihood(tree, dynamic_cast<MixedSubstitutionModelSet*>(modelSet_), hn, desc, rateDistribution_, false, usePatterns);
+        pr->resetParameters_();
+        mvTreeLikelihoods_[desc].push_back(pr);
+      }
+    }
+    else
+      for (size_t i = 0; i < vson.size(); i++)
+      {
+        vDesc.push_back(vson[i]);
+      }
   }
 }
 
-RHomogeneousMixedTreeLikelihood::RHomogeneousMixedTreeLikelihood(
-  const Tree& tree,
-  const SiteContainer& data,
-  TransitionModel* model,
-  DiscreteDistribution* rDist,
-  bool checkRooted,
-  bool verbose,
-  bool usePatterns) :
-  RHomogeneousTreeLikelihood(tree, model, rDist, checkRooted, verbose, usePatterns),
-  treeLikelihoodsContainer_(),
-  probas_()
+
+/******************************************************************************/
+
+RNonHomogeneousMixedTreeLikelihood::RNonHomogeneousMixedTreeLikelihood(
+  const RNonHomogeneousMixedTreeLikelihood& lik) :
+  RNonHomogeneousTreeLikelihood(lik),
+  mvTreeLikelihoods_(),
+  hyperNode_(lik.hyperNode_),
+  upperNode_(lik.upperNode_),
+  main_(lik.main_)
 {
-  MixedSubstitutionModel* mixedmodel;
-
-  if ((mixedmodel = dynamic_cast<MixedSubstitutionModel*>(model_)) == 0)
-    throw Exception("Bad model: RHomogeneousMixedTreeLikelihood needs a MixedSubstitutionModel.");
-
-  size_t s = mixedmodel->getNumberOfModels();
-  for (size_t i = 0; i < s; i++)
+  map<int, vector<RNonHomogeneousMixedTreeLikelihood*> >::const_iterator it;
+  for (it = lik.mvTreeLikelihoods_.begin(); it != lik.mvTreeLikelihoods_.end(); it++)
   {
-    treeLikelihoodsContainer_.push_back(
-      new RHomogeneousTreeLikelihood(tree, mixedmodel->getNModel(i), rDist, checkRooted, false, usePatterns));
-    probas_.push_back(mixedmodel->getNProbability(i));
+    for (size_t i = 0; i < it->second.size(); i++)
+    {
+      mvTreeLikelihoods_[it->first].push_back(new RNonHomogeneousMixedTreeLikelihood(*it->second[i]));
+    }
   }
-  setData(data);
 }
 
-RHomogeneousMixedTreeLikelihood& RHomogeneousMixedTreeLikelihood::operator=(const RHomogeneousMixedTreeLikelihood& lik)
+/******************************************************************************/
+
+RNonHomogeneousMixedTreeLikelihood& RNonHomogeneousMixedTreeLikelihood::operator=(
+  const RNonHomogeneousMixedTreeLikelihood& lik)
 {
-  RHomogeneousTreeLikelihood::operator=(lik);
+  RNonHomogeneousTreeLikelihood::operator=(lik);
 
-  treeLikelihoodsContainer_.clear();
-  probas_.clear();
+  mvTreeLikelihoods_.clear();
 
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
+  upperNode_ = lik.upperNode_;
+  main_ = lik.main_;
+
+  map<int, vector<RNonHomogeneousMixedTreeLikelihood*> >::const_iterator it;
+  for (it = lik.mvTreeLikelihoods_.begin(); it != lik.mvTreeLikelihoods_.end(); it++)
   {
-    treeLikelihoodsContainer_.push_back(lik.treeLikelihoodsContainer_[i]->clone());
-    probas_.push_back(lik.probas_[i]);
+    for (size_t i = 0; i < it->second.size(); i++)
+    {
+      mvTreeLikelihoods_[it->first].push_back(new RNonHomogeneousMixedTreeLikelihood(*it->second[i]));
+    }
   }
+
+  hyperNode_=lik.hyperNode_;
 
   return *this;
 }
 
+/******************************************************************************/
 
-RHomogeneousMixedTreeLikelihood::RHomogeneousMixedTreeLikelihood(const RHomogeneousMixedTreeLikelihood& lik) :
-  RHomogeneousTreeLikelihood(lik),
-  treeLikelihoodsContainer_(lik.treeLikelihoodsContainer_.size()),
-  probas_(lik.probas_.size())
+RNonHomogeneousMixedTreeLikelihood::~RNonHomogeneousMixedTreeLikelihood()
 {
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
+  map<int, vector<RNonHomogeneousMixedTreeLikelihood*> >::iterator it;
+  for (it = mvTreeLikelihoods_.begin(); it != mvTreeLikelihoods_.end(); it++)
   {
-    treeLikelihoodsContainer_[i] = lik.treeLikelihoodsContainer_[i]->clone();
-    probas_.push_back(lik.probas_[i]);
-  }
-}
-
-RHomogeneousMixedTreeLikelihood::~RHomogeneousMixedTreeLikelihood()
-{
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    delete treeLikelihoodsContainer_[i];
-  }
-}
-
-
-void RHomogeneousMixedTreeLikelihood::initialize()
-{
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    treeLikelihoodsContainer_[i]->initialize();
-  }
-  
-  RHomogeneousTreeLikelihood::initialize();
-}
-
-void RHomogeneousMixedTreeLikelihood::setData(const SiteContainer& sites)
-{
-  RHomogeneousTreeLikelihood::setData(sites);
-
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    treeLikelihoodsContainer_[i]->setData(sites);
-  }
-}
-
-
-void RHomogeneousMixedTreeLikelihood::fireParameterChanged(const ParameterList& params)
-{
-  // checks in the model will change
-  bool modelC=model_->getParameters().testParametersValues(params);
-
-  applyParameters();
-  MixedSubstitutionModel* mixedmodel = dynamic_cast<MixedSubstitutionModel*>(model_);
-  size_t s = mixedmodel->getNumberOfModels();
-
-  const TransitionModel* pm;
-  for (size_t i = 0; i < s; i++)
-  {
-    ParameterList pl;
-    pm = mixedmodel->getNModel(i);
-    pl.addParameters(pm->getParameters());
-    pl.includeParameters(getParameters());
-
-    if (modelC){
-      treeLikelihoodsContainer_[i]->setParameters(pl);
+    for (size_t i = 0; i < it->second.size(); i++)
+    {
+      delete it->second[i];
     }
+  }
+}
+
+/******************************************************************************/
+ void RNonHomogeneousMixedTreeLikelihood::initialize()
+{
+  if (main_)
+    initParameters();
+  else {
+    initBranchLengthsParameters(false);
+    includeParameters_(brLenParameters_);
+  }
+
+  map<int, vector<RNonHomogeneousMixedTreeLikelihood*> >::iterator it;
+  for (it = mvTreeLikelihoods_.begin(); it != mvTreeLikelihoods_.end(); it++)
+  {
+    for (size_t i = 0; i < it->second.size(); i++)
+    {
+      it->second[i]->initialize();
+    }
+  }
+
+  RNonHomogeneousTreeLikelihood::initialize();
+}
+
+/******************************************************************************/
+
+ void RNonHomogeneousMixedTreeLikelihood::fireParameterChanged(const ParameterList& params)
+{
+  if (main_)
+    applyParameters();
+  else {
+    for (size_t i = 0; i < nbNodes_; i++)
+      {
+        int id = nodes_[i]->getId();
+        if (reparametrizeRoot_ && id == root1_)
+          {
+            const Parameter* rootBrLen = &getParameter("BrLenRoot");
+            const Parameter* rootPos = &getParameter("RootPosition");
+            nodes_[i]->setDistanceToFather(rootBrLen->getValue() * rootPos->getValue());
+          }
+        else if (reparametrizeRoot_ && id == root2_)
+          {
+            const Parameter* rootBrLen = &getParameter("BrLenRoot");
+            const Parameter* rootPos = &getParameter("RootPosition");
+            nodes_[i]->setDistanceToFather(rootBrLen->getValue() * (1. - rootPos->getValue()));
+          }
+        else
+          {
+            const Parameter* brLen = &getParameter(string("BrLen") + TextTools::toString(i));
+            if (brLen) nodes_[i]->setDistanceToFather(brLen->getValue());
+          }
+      }
+  }
+
+  map<int, vector<RNonHomogeneousMixedTreeLikelihood*> >::const_iterator it2;
+  for (it2 = mvTreeLikelihoods_.begin(); it2 != mvTreeLikelihoods_.end(); it2++)
+    for (size_t i = 0; i < it2->second.size(); i++){
+      (it2->second)[i]->setProbability((dynamic_cast<MixedSubstitutionModelSet*>(modelSet_))->getHyperNodeProbability((it2->second)[i]->getHyperNode()));
+    }
+
+  if (main_){
+    for (size_t i=0;i< mvTreeLikelihoods_[upperNode_].size(); i++)
+      mvTreeLikelihoods_[upperNode_][i]->matchParametersValues(params);
+    rootFreqs_ = modelSet_->getRootFrequencies();
+  }
+  else {
+    if (params.getCommonParametersWith(rateDistribution_->getIndependentParameters()).size() > 0)
+      {
+        computeAllTransitionProbabilities();
+      }
     else
-      treeLikelihoodsContainer_[i]->matchParametersValues(pl);
+      {
+        vector<int> ids;
+        vector<string> tmp = params.getCommonParametersWith(modelSet_->getNodeParameters()).getParameterNames();
+        for (size_t i = 0; i < tmp.size(); i++)
+          {
+            vector<int> tmpv = modelSet_->getNodesWithParameter(tmp[i]);
+            ids = VectorTools::vectorUnion(ids, tmpv);
+          }
+        tmp = params.getCommonParametersWith(brLenParameters_).getParameterNames();
+        vector<const Node*> nodes;
+        for (size_t i = 0; i < ids.size(); i++)
+          {
+            nodes.push_back(idToNode_[ids[i]]);
+          }
+        vector<const Node*> tmpv;
+        bool test = false;
+        for (size_t i = 0; i < tmp.size(); i++)
+          {
+            if (tmp[i] == "BrLenRoot" || tmp[i] == "RootPosition")
+              {
+                if (!test)
+                  {
+                    tmpv.push_back(tree_->getRootNode()->getSon(0));
+                    tmpv.push_back(tree_->getRootNode()->getSon(1));
+                    test = true; // Add only once.
+                  }
+              }
+            else
+              tmpv.push_back(nodes_[TextTools::to < size_t > (tmp[i].substr(5))]);
+          }
+        nodes = VectorTools::vectorUnion(nodes, tmpv);
+        
+        for (size_t i = 0; i < nodes.size(); i++){
+          computeTransitionProbabilitiesForNode(nodes[i]);
+        }
+      }
+
+    map<int, vector<RNonHomogeneousMixedTreeLikelihood*> >::iterator it;
+    for (it = mvTreeLikelihoods_.begin(); it != mvTreeLikelihoods_.end(); it++)
+      {
+        for (size_t i = 0; i < it->second.size(); i++)
+          {
+            it->second[i]->matchParametersValues(params);
+          }
+      }
   }
   
-  probas_ = mixedmodel->getProbabilities();
-  minusLogLik_ = -getLogLikelihood();
+  if (main_)
+    {
+      computeTreeLikelihood();
+      minusLogLik_ = -getLogLikelihood();
+    }
 }
 
-void RHomogeneousMixedTreeLikelihood::computeTreeLikelihood()
+/******************************************************************************/
+void RNonHomogeneousMixedTreeLikelihood::setData(const SiteContainer& sites)
 {
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
+  RNonHomogeneousTreeLikelihood::setData(sites);
+  map<int, vector<RNonHomogeneousMixedTreeLikelihood*> >::iterator it;
+  for (it = mvTreeLikelihoods_.begin(); it != mvTreeLikelihoods_.end(); it++)
   {
-    treeLikelihoodsContainer_[i]->computeTreeLikelihood();
+    for (size_t i = 0; i < it->second.size(); i++)
+    {
+      it->second[i]->setData(sites);
+    }
   }
 }
 
-/******************************************************************************
- *                                   Likelihoods                              *
- ******************************************************************************/
-double RHomogeneousMixedTreeLikelihood::getLikelihoodForASiteForARateClass(size_t site, size_t rateClass) const
-{
-  double res = 0;
 
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    res += treeLikelihoodsContainer_[i]->getLikelihoodForASiteForARateClass(site, rateClass) * probas_[i];
+/******************************************************************************/
+double RNonHomogeneousMixedTreeLikelihood::getProbability() const
+{
+  return hyperNode_.getProbability();
+}
+
+/******************************************************************************/
+void RNonHomogeneousMixedTreeLikelihood::setProbability(double x)
+{
+  return hyperNode_.setProbability(x);
+}
+
+/******************************************************************************/
+
+void RNonHomogeneousMixedTreeLikelihood::computeSubtreeLikelihood(const Node* node)
+{
+  // if the subtree is divided in several RNonHomogeneousMixedTreeLikelihood*
+  if (node->isLeaf())
+    return;
+
+  int nodeId=main_?upperNode_:node->getId();
+  if (mvTreeLikelihoods_.find(nodeId) != mvTreeLikelihoods_.end()) {
+
+    size_t nbSites  = likelihoodData_->getLikelihoodArray(nodeId).size();
+    
+	// Must reset the likelihood array first (i.e. set all of them to 0):
+    VVVdouble* _likelihoods_node = &likelihoodData_->getLikelihoodArray(nodeId);
+    
+	// keren - make sure openmp compoent is successfully incorporated using a threads tracking procedure
+    #pragma omp parallel
+	{
+	// keren - execute the likelihood per site computation in parallel. The shared array is _likelihoods_node
+  #pragma omp for schedule(static, 4) // switch later (static, 4) with (dynamic, 100)
+	for (size_t i = 0; i < nbSites; i++)
+      {
+		// keren - print thread id for tracking procedure - woking indeed:)
+		//std::cout << "current thread_idx: " << omp_get_thread_num() << std::endl;
+		
+        // For each site in the sequence,
+        VVdouble* _likelihoods_node_i = &(*_likelihoods_node)[i];
+        for (size_t c = 0; c < nbClasses_; c++)
+          {
+              // For each rate classe,
+            Vdouble* _likelihoods_node_i_c = &(*_likelihoods_node_i)[c];
+            for (size_t x = 0; x < nbStates_; x++)
+              {
+                // For each initial state,
+                (*_likelihoods_node_i_c)[x] = 0.;
+              }
+          }
+      }
+	}
+
+    if (getProbability()==0)
+      return;
+  
+    vector<RNonHomogeneousMixedTreeLikelihood* > vr = mvTreeLikelihoods_[nodeId];
+    for (size_t t = 0; t < vr.size(); t++)
+      vr[t]->computeSubtreeLikelihood(node);
+
+    // for each specific subtree
+    for (size_t t = 0; t < vr.size(); t++)
+    {
+      VVVdouble* _vt_likelihoods_node = &vr[t]->likelihoodData_->getLikelihoodArray(nodeId);
+      // keren - make sure openmp compoent is successfully incorporated using a threads tracking procedure
+	    #pragma omp parallel
+	    {
+		  // keren - execute the likelihood per site computation in parallel. The shared array is _likelihoods_node
+		  #pragma omp for schedule(static, 4) // switch later (static, 4) with (dynamic, 100)
+		  for (size_t i = 0; i < nbSites; i++)
+		  {
+			// For each site in the sequence,
+			VVdouble* _likelihoods_node_i = &(*_likelihoods_node)[i];
+			for (size_t c = 0; c < nbClasses_; c++)
+			{
+			  // For each rate classe,
+			  Vdouble* _likelihoods_node_i_c = &(*_likelihoods_node_i)[c];
+			  Vdouble* _vt_likelihoods_node_i_c = &(*_vt_likelihoods_node)[i][c];
+			  for (size_t x = 0; x < nbStates_; x++)
+			  {
+				(*_likelihoods_node_i_c)[x] +=  (*_vt_likelihoods_node_i_c)[x] * vr[t]->getProbability()/getProbability();
+			  }
+			}
+		  }
+	  }
+    }
   }
+  
 
-  return res;
+  // otherwise...
+
+  // nb: if the subtree is made of independent branches the computing is
+  // as in the non mixed case, where the mean of the probas of
+  // transition of a mixed model are taken.
+
+  else
+    RNonHomogeneousTreeLikelihood::computeSubtreeLikelihood(node); 
 }
-
-double RHomogeneousMixedTreeLikelihood::getLogLikelihoodForASiteForARateClass(size_t site, size_t rateClass) const
-{
-  double x = getLikelihoodForASiteForARateClass(site, rateClass);
-  if (x < 0)
-    x = 0;
-  return log(x);
-}
-
-double RHomogeneousMixedTreeLikelihood::getLikelihoodForASiteForARateClassForAState(size_t site, size_t rateClass, int state) const
-{
-  double res = 0;
-
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    res += treeLikelihoodsContainer_[i]->getLikelihoodForASiteForARateClassForAState(site, rateClass, state) * probas_[i];
-  }
-
-  return res;
-}
-
-double RHomogeneousMixedTreeLikelihood::getLogLikelihoodForASiteForARateClassForAState(size_t site, size_t rateClass, int state) const
-{
-  double x = getLikelihoodForASiteForARateClassForAState(site, rateClass, state);
-  if (x < 0)
-    x = 0;
-  return log(x);
-}
-
 
 /******************************************************************************
 *                           First Order Derivatives                          *
 ******************************************************************************/
-double RHomogeneousMixedTreeLikelihood::getDLikelihoodForASiteForARateClass(size_t site, size_t rateClass) const
+void RNonHomogeneousMixedTreeLikelihood::computeTreeDLikelihood(const string& variable)
 {
-  double res = 0;
-
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    res += treeLikelihoodsContainer_[i]->getDLikelihoodForASiteForARateClass(site, rateClass) * probas_[i];
+  const Node* father, father2;
+    
+    
+  if (main_)
+    father = tree_->getRootNode();
+  else {
+    if ((variable == "BrLenRoot") ||  (variable == "RootPosition"))
+      father = tree_->getRootNode();
+    else
+      {
+        size_t brI = TextTools::to<size_t>(variable.substr(5));
+        const Node* branch = nodes_[brI];
+        father = branch->getFather();
+      }
   }
+  
+  bool flok = 0;
+  while (father){
+    if (mvTreeLikelihoods_.find(father->getId()) != mvTreeLikelihoods_.end()) {
+      flok = 1;
+      break;
+    }
+    if (father->getId() == upperNode_)
+      break;
+    father = father->getFather();
+  }
+    
+  if (flok) {  // there is an expanded model above the derivated branch
+    int fatherId = father->getId();
+    // Compute dLikelihoods array for the father node.
+    // Fist initialize to 0:
+    VVVdouble* _dLikelihoods_father = &likelihoodData_->getDLikelihoodArray(fatherId);
+    size_t nbSites  = _dLikelihoods_father->size();
+    #pragma omp parallel
+	  {
+      // keren - execute the likelihood per site computation in parallel. The shared array is _likelihoods_node
+      #pragma omp for schedule(static, 4) // switch later (static, 4) with (dynamic, 100) 
+      for (size_t i = 0; i < nbSites; i++) {
+        VVdouble* _dLikelihoods_father_i = &(*_dLikelihoods_father)[i];
+        for (size_t c = 0; c < nbClasses_; c++) {
+          Vdouble* _dLikelihoods_father_i_c = &(*_dLikelihoods_father_i)[c];
+          for (size_t s = 0; s < nbStates_; s++){
+            (*_dLikelihoods_father_i_c)[s] = 0.;
+          }
+        }
+      }
+    }
 
-  return res;
+    if (getProbability()!=0){
+      vector<RNonHomogeneousMixedTreeLikelihood* > vr = mvTreeLikelihoods_[fatherId];
+      for (size_t t = 0; t < vr.size(); t++)
+        vr[t]->computeTreeDLikelihood(variable);
+      
+    
+      // for each specific subtree
+      for (size_t t = 0; t < vr.size(); t++) {
+        VVVdouble* _vt_dLikelihoods_father = &vr[t]->likelihoodData_->getDLikelihoodArray(fatherId);
+        #pragma omp parallel
+	      {
+          // keren - execute the likelihood per site computation in parallel. The shared array is _likelihoods_node
+          #pragma omp for schedule(static, 4) // switch later (static, 4) with (dynamic, 100)
+          for (size_t i = 0; i < nbSites; i++){
+            // For each site in the sequence,
+            VVdouble* _dLikelihoods_father_i = &(*_dLikelihoods_father)[i];
+            for (size_t c = 0; c < nbClasses_; c++){
+              // For each rate classe,
+              Vdouble* _dLikelihoods_father_i_c = &(*_dLikelihoods_father_i)[c];
+              Vdouble* _vt_dLikelihoods_father_i_c = &(*_vt_dLikelihoods_father)[i][c];
+              for (size_t x = 0; x < nbStates_; x++) {
+                (*_dLikelihoods_father_i_c)[x] +=  (*_vt_dLikelihoods_father_i_c)[x] * vr[t]->getProbability()/getProbability();
+              }
+            }
+          }
+        }
+      }
+    }
+    computeDownSubtreeDLikelihood(father);
+  }
+  else
+    RNonHomogeneousTreeLikelihood::computeTreeDLikelihood(variable); 
 }
 
-void RHomogeneousMixedTreeLikelihood::computeTreeDLikelihood(const string& variable)
+void RNonHomogeneousMixedTreeLikelihood::computeDownSubtreeDLikelihood(const Node* node)
 {
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    treeLikelihoodsContainer_[i]->computeTreeDLikelihood(variable);
-  }
+  const Node* father = node->getFather();
+  // // We assume that the _dLikelihoods array has been filled for the current node 'node'.
+  // // We will evaluate the array for the father node.
+  if (father == 0)
+    return;  // We reached the up!
+
+  if (node->getId() == upperNode_)
+    return;  // We reached the top of the subtree
+
+  RNonHomogeneousTreeLikelihood::computeDownSubtreeDLikelihood(node);
 }
 
 /******************************************************************************
-*                           Second Order Derivatives                          *
+*                           Second Order Derivatives                         *
 ******************************************************************************/
-double RHomogeneousMixedTreeLikelihood::getD2LikelihoodForASiteForARateClass(size_t site, size_t rateClass) const
+void RNonHomogeneousMixedTreeLikelihood::computeTreeD2Likelihood(const string& variable)
 {
-  double res = 0;
+  const Node* father, father2;
 
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    res += treeLikelihoodsContainer_[i]->getD2LikelihoodForASiteForARateClass(site, rateClass) * probas_[i];
+  if (main_)
+    father = tree_->getRootNode();
+  else {
+    if ((variable == "BrLenRoot") ||  (variable == "RootPosition"))
+      father = tree_->getRootNode();
+    else
+      {
+        size_t brI = TextTools::to<size_t>(variable.substr(5));
+        const Node* branch = nodes_[brI];
+        father = branch->getFather();
+      }
+  }
+  
+  bool flok = 0;
+  while (father){
+    if (mvTreeLikelihoods_.find(father->getId()) != mvTreeLikelihoods_.end())
+      {
+        flok = 1;
+        break;
+      }
+    if (father->getId() == upperNode_)
+      break;
+    father = father->getFather();
   }
 
-  return res;
+  if (flok)  // there is an expanded model above the derivated branch
+    {
+      int fatherId = father->getId();
+      // Compute d2Likelihoods array for the father node.
+      // Fist initialize to 0:
+      VVVdouble* _d2Likelihoods_father = &likelihoodData_->getD2LikelihoodArray(fatherId);
+      size_t nbSites  = _d2Likelihoods_father->size();
+      #pragma omp parallel
+	    {
+        // keren - execute the likelihood per site computation in parallel. The shared array is _likelihoods_node
+        #pragma omp for schedule(static, 4) // switch later (static, 4) with (dynamic, 100)
+        for (size_t i = 0; i < nbSites; i++) {
+          VVdouble* _d2Likelihoods_father_i = &(*_d2Likelihoods_father)[i];
+          for (size_t c = 0; c < nbClasses_; c++) {
+            Vdouble* _d2Likelihoods_father_i_c = &(*_d2Likelihoods_father_i)[c];
+            for (size_t s = 0; s < nbStates_; s++) {
+              (*_d2Likelihoods_father_i_c)[s] = 0.;
+            }
+          }
+        }
+      }
+
+      if (getProbability()!=0){
+        
+        vector<RNonHomogeneousMixedTreeLikelihood* > vr = mvTreeLikelihoods_[fatherId];
+        for (size_t t = 0; t < vr.size(); t++)
+          vr[t]->computeTreeD2Likelihood(variable);
+      
+        // for each specific subtree
+        for (size_t t = 0; t < vr.size(); t++) {
+          VVVdouble* _vt_d2Likelihoods_father = &vr[t]->likelihoodData_->getD2LikelihoodArray(fatherId);
+          #pragma omp parallel
+          {
+            // keren - execute the likelihood per site computation in parallel. The shared array is _likelihoods_node
+            #pragma omp for schedule(static, 4) // switch later (static, 4) with (dynamic, 100)
+            for (size_t i = 0; i < nbSites; i++) {
+              // For each site in the sequence,
+              VVdouble* _d2Likelihoods_father_i = &(*_d2Likelihoods_father)[i];
+              for (size_t c = 0; c < nbClasses_; c++){
+                // For each rate classe,
+                Vdouble* _d2Likelihoods_father_i_c = &(*_d2Likelihoods_father_i)[c];
+                Vdouble* _vt_d2Likelihoods_father_i_c = &(*_vt_d2Likelihoods_father)[i][c];
+                for (size_t x = 0; x < nbStates_; x++) {
+                  (*_d2Likelihoods_father_i_c)[x] +=  (*_vt_d2Likelihoods_father_i_c)[x] * vr[t]->getProbability() / getProbability();
+                }
+              }
+            }
+          }
+        }
+      }
+      computeDownSubtreeD2Likelihood(father);
+    }
+  else
+    RNonHomogeneousTreeLikelihood::computeTreeD2Likelihood(variable);
 }
 
 
-void RHomogeneousMixedTreeLikelihood::computeTreeD2Likelihood(const string& variable)
+void RNonHomogeneousMixedTreeLikelihood::computeDownSubtreeD2Likelihood(const Node* node)
 {
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    treeLikelihoodsContainer_[i]->computeTreeD2Likelihood(variable);
-  }
-}
+  const Node* father = node->getFather();
+  // // We assume that the _dLikelihoods array has been filled for the current node 'node'.
+  // // We will evaluate the array for the father node.
+  if (father == 0)
+    return;  // We reached the up!
 
-void RHomogeneousMixedTreeLikelihood::computeSubtreeLikelihood(const Node* node)
-{
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    treeLikelihoodsContainer_[i]->computeSubtreeLikelihood(node);
-  }
-}
+  if (node->getId() == upperNode_)
+    return;  // We reached the top of the subtree
 
-void RHomogeneousMixedTreeLikelihood::computeDownSubtreeDLikelihood(const Node* node)
-{
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    treeLikelihoodsContainer_[i]->computeDownSubtreeDLikelihood(node);
-  }
-}
-
-void RHomogeneousMixedTreeLikelihood::computeDownSubtreeD2Likelihood(const Node* node)
-{
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    treeLikelihoodsContainer_[i]->computeDownSubtreeD2Likelihood(node);
-  }
+  RNonHomogeneousTreeLikelihood::computeDownSubtreeD2Likelihood(node);
 }
 
 
-void RHomogeneousMixedTreeLikelihood::computeAllTransitionProbabilities()
+/*******************************************************************************/
+
+void RNonHomogeneousMixedTreeLikelihood::computeTransitionProbabilitiesForNode(const Node* node)
 {
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    treeLikelihoodsContainer_[i]->computeAllTransitionProbabilities();
+  const TransitionModel* model = modelSet_->getModelForNode(node->getId());
+  size_t modelnum = modelSet_->getModelIndexForNode(node->getId());
+
+  vector<const TransitionModel*> vModel;
+  vector<double> vProba;
+  
+  const MixedSubstitutionModelSet::HyperNode::Node& nd = hyperNode_.getNode(modelnum);
+  if (nd.size() == 0) {
+    vModel.push_back(model);
+    vProba.push_back(1);
   }
+  else {
+    const MixedSubstitutionModel* mmodel = dynamic_cast<const MixedSubstitutionModel*>(model);
+    double x = 0;
+    for (size_t i = 0; i < nd.size(); ++i){
+      vModel.push_back(mmodel->getNModel(static_cast<size_t>(nd[i])));
+      vProba.push_back(mmodel->getNProbability(static_cast<size_t>(nd[i])));
+      x += vProba[i];
+    }
+    if (x != 0)
+      for (size_t i = 0; i < nd.size(); ++i)
+        vProba[i] /= x;
+  }
+
+  double l = node->getDistanceToFather();
+  // Computes all pxy and pyx once for all:
+  VVVdouble* pxy__node = &pxy_[node->getId()];
+  for (size_t c = 0; c < nbClasses_; c++) {
+    VVdouble* pxy__node_c = &(*pxy__node)[c];
+    for (size_t x = 0; x < nbStates_; x++){
+      Vdouble* pxy__node_c_x = &(*pxy__node_c)[x];
+      for (size_t y = 0; y < nbStates_; y++){
+        (*pxy__node_c_x)[y] = 0;
+      }
+    }
+    
+    for (size_t i=0;i<vModel.size();i++){
+      RowMatrix<double> Q = vModel[i]->getPij_t(l * rateDistribution_->getCategory(c));
+      for (size_t x = 0; x < nbStates_; x++){
+        Vdouble* pxy__node_c_x = &(*pxy__node_c)[x];
+        for (size_t y = 0; y < nbStates_; y++){
+          (*pxy__node_c_x)[y] += vProba[i] * Q(x, y);
+        }
+      }
+    }
+  }
+  
+  if (computeFirstOrderDerivatives_) {
+    // Computes all dpxy/dt once for all:
+    VVVdouble* dpxy__node = &dpxy_[node->getId()];
+
+    for (size_t c = 0; c < nbClasses_; c++){
+      VVdouble* dpxy__node_c = &(*dpxy__node)[c];
+      double rc = rateDistribution_->getCategory(c);
+      for (size_t x = 0; x < nbStates_; x++){
+        Vdouble* dpxy__node_c_x = &(*dpxy__node_c)[x];
+        for (size_t y = 0; y < nbStates_; y++){
+          (*dpxy__node_c_x)[y] = 0;
+        }
+      }
+
+      for (size_t i=0;i<vModel.size();i++){
+        RowMatrix<double> dQ = vModel[i]->getdPij_dt(l * rc);
+
+        for (size_t x = 0; x < nbStates_; x++){
+          Vdouble* dpxy__node_c_x = &(*dpxy__node_c)[x];
+          for (size_t y = 0; y < nbStates_; y++){
+            (*dpxy__node_c_x)[y] +=  vProba[i] * rc * dQ(x, y);
+          }
+        }
+      }
+    }
+  }
+  
+  if (computeSecondOrderDerivatives_) {
+    // Computes all d2pxy/dt2 once for all:
+    VVVdouble* d2pxy__node = &d2pxy_[node->getId()];
+    for (size_t c = 0; c < nbClasses_; c++){
+      VVdouble* d2pxy__node_c = &(*d2pxy__node)[c];
+      for (size_t x = 0; x < nbStates_; x++){
+        Vdouble* d2pxy__node_c_x = &(*d2pxy__node_c)[x];
+        for (size_t y = 0; y < nbStates_; y++){
+          (*d2pxy__node_c_x)[y] = 0;
+        }
+      }
+      
+      double rc =  rateDistribution_->getCategory(c);
+      for (size_t i=0;i<vModel.size();i++){
+        RowMatrix<double> d2Q = vModel[i]->getd2Pij_dt2(l * rc);
+        for (size_t x = 0; x < nbStates_; x++){
+          Vdouble* d2pxy__node_c_x = &(*d2pxy__node_c)[x];
+          for (size_t y = 0; y < nbStates_; y++){
+            (*d2pxy__node_c_x)[y] +=  vProba[i] * rc * rc * d2Q(x, y);
+          }
+        }
+      }
+    }
+  }
+  
 }
 
-
-void RHomogeneousMixedTreeLikelihood::computeTransitionProbabilitiesForNode(const Node* node)
-{
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    treeLikelihoodsContainer_[i]->computeTransitionProbabilitiesForNode(node);
-  }
-}
-
-
-void RHomogeneousMixedTreeLikelihood::displayLikelihood(const Node* node)
-{
-  for (size_t i = 0; i < treeLikelihoodsContainer_.size(); i++)
-  {
-    treeLikelihoodsContainer_[i]->displayLikelihood(node);
-  }
-}
+/*******************************************************************************/


### PR DESCRIPTION
Dear Bio++ team,

Following the post linked [here](https://groups.google.com/forum/#!category-topic/biopp-help-forum/all-questions/oZXbB53hHCg), I am pulling request a VERY basic embedding of openmp to allow parallelization of likelihood computation with respect to sequence positions. 

The implementation uses static allocation of 4 threads, but can be made into dynamic allocation according to some environment variable, according to your needs.

Cheers!
Keren