### PR TITLE
Fix compilation error: missing parentheses in arr.cols() call in ExtendedFloatEigen.h

### DIFF
--- a/src/Bpp/Phyl/Likelihood/DataFlow/ExtendedFloatEigen.h
+++ b/src/Bpp/Phyl/Likelihood/DataFlow/ExtendedFloatEigen.h
@@ -425,7 +425,7 @@ public:
   inline static Self denorm_pow (const Self& arr, int exp)
   {
     if (exp == 0)
-      return Self::Ones(arr.rows(), arr.cols);
+      return Self::Ones(arr.rows(), arr.cols());
     if (exp & 1)
       return exp > 0 ? denorm_mul(arr, denorm_pow(arr, exp - 1)) : denorm_div(denorm_pow(arr, exp + 1), arr);
     else


### PR DESCRIPTION
Dear maintainers,

I encountered a compilation error when building `bpp-phyl`.

### The Issue
In `src/Bpp/Phyl/Likelihood/DataFlow/ExtendedFloatEigen.h` at line 428:
```cpp
return Self::Ones(arr.rows(), arr.cols);
```

`arr.cols` is referenced without parentheses. However, `cols` is defined as a member function, not a member variable, within the `ExtendedFloatEigen` class (lines 733-736 in the same file). This causes the following error:

> error: reference to non-static member function must be called

### The Fix

I have added parentheses `()` to correctly call the function, matching the usage of `arr.rows()` on the same line.