### PR TITLE
Add getters for the states and times objects

### DIFF
--- a/src/Bpp/Phyl/Simulation/MutationProcess.h
+++ b/src/Bpp/Phyl/Simulation/MutationProcess.h
@@ -79,6 +79,10 @@ public:
    */
   std::shared_ptr<const Alphabet> getAlphabet() const { return alphabet_; }
 
+ const std::vector<size_t> getStates() const { return states_; }
+
+  const std::vector<double> getTimes() const { return times_; }
+
   /**
    * @return A reference toward the alphabet associated to this path.
    */


### PR DESCRIPTION
This PR adds getter functions for both the states and times objects of the mutation path class. This is useful for understanding simulation dynamics and processes.